### PR TITLE
chore(utils): Update the integrity proof public inputs to be unix timestamp

### DIFF
--- a/packages/zkpassport-utils/src/circuit-matcher.ts
+++ b/packages/zkpassport-utils/src/circuit-matcher.ts
@@ -581,9 +581,11 @@ export async function getIntegrityCheckCircuitInputs(
     Binary.from(idData.e_content).padEnd(E_CONTENT_INPUT_SIZE),
     privateNullifier.toBigInt(),
   )
+  // UNIX timestamp in seconds
+  const timestamp = Math.floor(Date.now() / 1000)
 
   return {
-    current_date: format(new Date(), "yyyyMMdd"),
+    current_date: timestamp,
     dg1: idData.dg1,
     signed_attributes: idData.signed_attributes,
     signed_attributes_size: idData.signed_attributes_size,

--- a/packages/zkpassport-utils/src/circuit-matcher.ts
+++ b/packages/zkpassport-utils/src/circuit-matcher.ts
@@ -1,7 +1,7 @@
 import { sha256 } from "@noble/hashes/sha2"
 import { AsnParser } from "@peculiar/asn1-schema"
 import { AuthorityKeyIdentifier, PrivateKeyUsagePeriod } from "@peculiar/asn1-x509"
-import { format } from "date-fns"
+import { format, formatDate } from "date-fns"
 import { Alpha3Code } from "i18n-iso-countries"
 import { redcLimbsFromBytes } from "./barrett-reduction"
 import { Binary, HexString } from "./binary"
@@ -585,7 +585,8 @@ export async function getIntegrityCheckCircuitInputs(
   const timestamp = Math.floor(Date.now() / 1000)
 
   return {
-    current_date: timestamp,
+    current_date: formatDate(new Date(), "yyyyMMdd"),
+    timestamp: timestamp,
     dg1: idData.dg1,
     signed_attributes: idData.signed_attributes,
     signed_attributes_size: idData.signed_attributes_size,

--- a/packages/zkpassport-utils/tests/circuit-matcher.test.ts
+++ b/packages/zkpassport-utils/tests/circuit-matcher.test.ts
@@ -1,4 +1,4 @@
-import { format } from "date-fns"
+import { format, formatDate } from "date-fns"
 import { Alpha3Code } from "i18n-iso-countries"
 import {
   calculateAge,
@@ -319,7 +319,8 @@ describe("Circuit Matcher - RSA", () => {
   it("should get the right integrity check circuit inputs", async () => {
     const result = await getIntegrityCheckCircuitInputs(PASSPORTS.john, 1n, 1n)
     expect(result).toEqual({
-      current_date: Math.floor(Date.now() / 1000),
+      current_date: formatDate(new Date(), "yyyyMMdd"),
+      timestamp: Math.floor(Date.now() / 1000),
       dg1: rightPadArrayWithZeros(PASSPORTS.john.dataGroups[0].value, 95),
       signed_attributes: rightPadArrayWithZeros(
         PASSPORTS.john.sod.signerInfo.signedAttrs.bytes.toNumberArray(),
@@ -617,7 +618,8 @@ describe("Circuit Matcher - ECDSA", () => {
   it("should get the right integrity check circuit inputs", async () => {
     const result = await getIntegrityCheckCircuitInputs(PASSPORTS.mary, 1n, 1n)
     expect(result).toEqual({
-      current_date: Math.floor(Date.now() / 1000),
+      current_date: formatDate(new Date(), "yyyyMMdd"),
+      timestamp: Math.floor(Date.now() / 1000),
       dg1: rightPadArrayWithZeros(PASSPORTS.mary.dataGroups[0].value, DG1_INPUT_SIZE),
       signed_attributes: rightPadArrayWithZeros(
         PASSPORTS.mary.sod.signerInfo.signedAttrs.bytes.toNumberArray(),

--- a/packages/zkpassport-utils/tests/circuit-matcher.test.ts
+++ b/packages/zkpassport-utils/tests/circuit-matcher.test.ts
@@ -319,7 +319,7 @@ describe("Circuit Matcher - RSA", () => {
   it("should get the right integrity check circuit inputs", async () => {
     const result = await getIntegrityCheckCircuitInputs(PASSPORTS.john, 1n, 1n)
     expect(result).toEqual({
-      current_date: format(new Date(), "yyyyMMdd"),
+      current_date: Math.floor(Date.now() / 1000),
       dg1: rightPadArrayWithZeros(PASSPORTS.john.dataGroups[0].value, 95),
       signed_attributes: rightPadArrayWithZeros(
         PASSPORTS.john.sod.signerInfo.signedAttrs.bytes.toNumberArray(),
@@ -617,7 +617,7 @@ describe("Circuit Matcher - ECDSA", () => {
   it("should get the right integrity check circuit inputs", async () => {
     const result = await getIntegrityCheckCircuitInputs(PASSPORTS.mary, 1n, 1n)
     expect(result).toEqual({
-      current_date: format(new Date(), "yyyyMMdd"),
+      current_date: Math.floor(Date.now() / 1000),
       dg1: rightPadArrayWithZeros(PASSPORTS.mary.dataGroups[0].value, DG1_INPUT_SIZE),
       signed_attributes: rightPadArrayWithZeros(
         PASSPORTS.mary.sod.signerInfo.signedAttrs.bytes.toNumberArray(),


### PR DESCRIPTION
ZKP-91 Update utils to return timestamp instead of current date string for 3rd subproof

- NEED clarity, is this in days or seconds? 