### PR TITLE
chore(explorer): Temporarily disable certificates validation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -50,7 +50,7 @@
     },
     "packages/registry-sdk": {
       "name": "@zkpassport/registry",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "dependencies": {
         "@zkpassport/utils": "workspace:*",
         "debug": "^4.4.0",

--- a/packages/registry-explorer/hooks/useCertificates.ts
+++ b/packages/registry-explorer/hooks/useCertificates.ts
@@ -100,7 +100,7 @@ export const useCertificates = () => {
         }
 
         // Only validate certificates in production
-        const validate = process.env.NODE_ENV !== "development"
+        const validate = false //process.env.NODE_ENV !== "development"
 
         const rootFromUrl = searchParams.get("root")
         const latestRoot = await client.getLatestCertificateRoot()

--- a/packages/registry-sdk/package.json
+++ b/packages/registry-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkpassport/registry",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Registry SDK for interacting with the ZKPassport Registry",
   "author": "ZKPassport",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR temporarily disables the validation of certificates on the registry explorer as we are in the middle of a breaking update that has not yet been applied, changing the logic behind the validation of certificates.