### PR TITLE
chore(utils): Switch from date strings to timestamps

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -91,7 +91,7 @@
     },
     "packages/zkpassport-utils": {
       "name": "@zkpassport/utils",
-      "version": "0.20.0",
+      "version": "0.20.1",
       "dependencies": {
         "@lapo/asn1js": "^2.0.4",
         "@noble/ciphers": "^1.0.0",

--- a/packages/registry-contracts/script/bash/update-roots.sh
+++ b/packages/registry-contracts/script/bash/update-roots.sh
@@ -8,6 +8,8 @@ export ETHERSCAN_API_KEY=${ETHERSCAN_API_KEY:-dummy}
 
 export ORACLE_ADDRESS=0x70997970C51812dc3A010C7d01b50e0d17dc79C8
 export ORACLE_PRIVATE_KEY=0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
+export CERTIFICATE_REGISTRY_ROOT=${CERTIFICATE_REGISTRY_ROOT:-0x2a41b0fbf6dd654ffeacdedaed2625b68b5e483e12f83b38bfafb034e6eeb918}
+export CIRCUIT_REGISTRY_ROOT=${CIRCUIT_REGISTRY_ROOT:-0x068f6e356f993bd2afaf3d3466efff1dd4bc06f61952ac336085b832b93289a7}
 
 # Function to generate SHA-256 hash that works on both macOS and Linux
 generate_sha256() {
@@ -38,7 +40,7 @@ do
 
   # Use the certificates fixture root hash and cid for the last root update
   if [ $i -eq 10 ]; then
-    ROOT="0x2a41b0fbf6dd654ffeacdedaed2625b68b5e483e12f83b38bfafb034e6eeb918"
+    ROOT=$CERTIFICATE_REGISTRY_ROOT
     CID="0x2faca44e2b6e4e88a8bbba15bc53b0a7604b693c7733d3d4995c445b5a6258a2" # QmRYkZEm7ueX8XT82QuYTdL6iivv3gryoi2jJsPzvsdu6H
     LEAVES_COUNT=5
   fi
@@ -70,7 +72,7 @@ do
 
   # Use the circuit manifest fixture root hash and cid for the last root update
   if [ $i -eq 10 ]; then
-    ROOT="0x068f6e356f993bd2afaf3d3466efff1dd4bc06f61952ac336085b832b93289a7"
+    ROOT=$CIRCUIT_REGISTRY_ROOT
     CID="0xc49583d83cde885ac798b7bd39f9910ba72b72faf27cbda4a5fcf951c3282019" # bafybeigeswb5qpg6rbnmpgfxxu47teilu4vxf6xsps62jjp47fi4gkbade
     LEAVES_COUNT=5
   fi

--- a/packages/zkpassport-utils/package.json
+++ b/packages/zkpassport-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkpassport/utils",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "type": "module",
   "main": "./dist/esm/index.js",
   "types": "./dist/esm/index.d.ts",

--- a/packages/zkpassport-utils/src/circuit-matcher.ts
+++ b/packages/zkpassport-utils/src/circuit-matcher.ts
@@ -1,7 +1,6 @@
 import { sha256 } from "@noble/hashes/sha2"
 import { AsnParser } from "@peculiar/asn1-schema"
 import { AuthorityKeyIdentifier, PrivateKeyUsagePeriod } from "@peculiar/asn1-x509"
-import { format, formatDate } from "date-fns"
 import { Alpha3Code } from "i18n-iso-countries"
 import { redcLimbsFromBytes } from "./barrett-reduction"
 import { Binary, HexString } from "./binary"
@@ -48,6 +47,7 @@ import {
   fromBytesToBigInt,
   getBitSize,
   getOffsetInArray,
+  getUnixTimestamp,
   leftPadArrayWithZeros,
   rightPadArrayWithZeros,
 } from "./utils"
@@ -557,6 +557,7 @@ export async function getIntegrityCheckCircuitInputs(
   passport: PassportViewModel,
   saltIn: bigint,
   saltOut: bigint,
+  currentDateTimestamp: number,
 ) {
   const maxTbsLength = getTBSMaxLen(passport)
   const dscData = getDSCDataInputs(passport, maxTbsLength)
@@ -581,12 +582,9 @@ export async function getIntegrityCheckCircuitInputs(
     Binary.from(idData.e_content).padEnd(E_CONTENT_INPUT_SIZE),
     privateNullifier.toBigInt(),
   )
-  // UNIX timestamp in seconds
-  const timestamp = Math.floor(Date.now() / 1000)
 
   return {
-    current_date: formatDate(new Date(), "yyyyMMdd"),
-    timestamp: timestamp,
+    current_date: currentDateTimestamp,
     dg1: idData.dg1,
     signed_attributes: idData.signed_attributes,
     signed_attributes_size: idData.signed_attributes_size,
@@ -813,6 +811,7 @@ export async function getAgeCircuitInputs(
   salt: bigint,
   service_scope: bigint = 0n,
   service_subscope: bigint = 0n,
+  currentDateTimestamp: number,
 ): Promise<any> {
   const idData = await getIDDataInputs(passport)
   if (!idData) return null
@@ -858,7 +857,7 @@ export async function getAgeCircuitInputs(
 
   return {
     dg1: idData.dg1,
-    current_date: format(new Date(), "yyyyMMdd"),
+    current_date: currentDateTimestamp,
     comm_in: commIn.toHex(),
     private_nullifier: privateNullifier.toHex(),
     service_scope: `0x${service_scope.toString(16)}`,
@@ -1035,6 +1034,7 @@ export async function getBirthdateCircuitInputs(
   salt: bigint,
   service_scope: bigint = 0n,
   service_subscope: bigint = 0n,
+  currentDateTimestamp: number,
 ): Promise<any> {
   const idData = getIDDataInputs(passport)
   if (!idData) return null
@@ -1078,15 +1078,14 @@ export async function getBirthdateCircuitInputs(
 
   return {
     dg1: idData.dg1,
-    current_date: format(new Date(), "yyyyMMdd"),
+    current_date: currentDateTimestamp,
     comm_in: commIn.toHex(),
     private_nullifier: privateNullifier.toHex(),
     service_scope: `0x${service_scope.toString(16)}`,
     service_subscope: `0x${service_subscope.toString(16)}`,
     salt: `0x${salt.toString(16)}`,
-    // "11111111" means the date is ignored
-    min_date: minDate ? format(minDate, "yyyyMMdd") : "1".repeat(8),
-    max_date: maxDate ? format(maxDate, "yyyyMMdd") : "1".repeat(8),
+    min_date: minDate ? getUnixTimestamp(minDate) : 0,
+    max_date: maxDate ? getUnixTimestamp(maxDate) : 0,
   }
 }
 
@@ -1096,6 +1095,7 @@ export async function getExpiryDateCircuitInputs(
   salt: bigint,
   service_scope: bigint = 0n,
   service_subscope: bigint = 0n,
+  currentDateTimestamp: number,
 ): Promise<any> {
   const idData = getIDDataInputs(passport)
   if (!idData) return null
@@ -1139,15 +1139,14 @@ export async function getExpiryDateCircuitInputs(
 
   return {
     dg1: idData.dg1,
-    current_date: format(new Date(), "yyyyMMdd"),
+    current_date: currentDateTimestamp,
     comm_in: commIn.toHex(),
     private_nullifier: privateNullifier.toHex(),
     service_scope: `0x${service_scope.toString(16)}`,
     service_subscope: `0x${service_subscope.toString(16)}`,
     salt: `0x${salt.toString(16)}`,
-    // "11111111" means the date is ignored
-    min_date: minDate ? format(minDate, "yyyyMMdd") : "1".repeat(8),
-    max_date: maxDate ? format(maxDate, "yyyyMMdd") : "1".repeat(8),
+    min_date: minDate ? getUnixTimestamp(minDate) : 0,
+    max_date: maxDate ? getUnixTimestamp(maxDate) : 0,
   }
 }
 

--- a/packages/zkpassport-utils/src/circuits/country.ts
+++ b/packages/zkpassport-utils/src/circuits/country.ts
@@ -2,7 +2,7 @@ import { Alpha3Code } from "i18n-iso-countries"
 import { poseidon2HashAsync } from "@zkpassport/poseidon2"
 import { packBeBytesIntoField, rightPadArrayWithZeros } from "../utils"
 import { CountryCommittedInputs } from "../types"
-import { sha256 } from "@noble/hashes/sha256"
+import { sha256 } from "@noble/hashes/sha2"
 import { ProofType } from "."
 
 export function getCountryWeightedSum(country: Alpha3Code): number {

--- a/packages/zkpassport-utils/src/circuits/disclose.ts
+++ b/packages/zkpassport-utils/src/circuits/disclose.ts
@@ -1,7 +1,7 @@
 import { packBeBytesIntoField, rightPadArrayWithZeros } from "../utils"
 import { ProofData, ProofType } from "."
 import { poseidon2HashAsync } from "@zkpassport/poseidon2"
-import { sha256 } from "@noble/hashes/sha256"
+import { sha256 } from "@noble/hashes/sha2"
 
 interface DisclosedDataRaw {
   issuingCountry: Uint8Array // 3 bytes

--- a/packages/zkpassport-utils/src/circuits/index.ts
+++ b/packages/zkpassport-utils/src/circuits/index.ts
@@ -1,7 +1,6 @@
 import { poseidon2HashAsync } from "@zkpassport/poseidon2"
 import { format } from "date-fns"
 import {
-  convertDateBytesToDate,
   getBindProofPublicInputCount,
   getCountryExclusionProofPublicInputCount,
   getCountryInclusionProofPublicInputCount,
@@ -190,11 +189,11 @@ export function getNumberOfPublicInputs(circuitName: string) {
 export function getCommittedInputCount(circuitName: DisclosureCircuitName) {
   switch (circuitName) {
     case "compare_age_evm":
-      return 11
+      return 7
     case "compare_birthdate_evm":
-      return 25
+      return 13
     case "compare_expiry_evm":
-      return 25
+      return 13
     case "disclose_bytes_evm":
       return 181
     case "inclusion_check_issuing_country_evm":
@@ -206,11 +205,11 @@ export function getCommittedInputCount(circuitName: DisclosureCircuitName) {
     case "exclusion_check_nationality_evm":
       return 601
     case "compare_age":
-      return 11
+      return 4
     case "compare_birthdate":
-      return 25
+      return 4
     case "compare_expiry":
-      return 25
+      return 4
     case "disclose_bytes":
       return 181
     case "inclusion_check_issuing_country":
@@ -241,10 +240,8 @@ export function getDateBytes(date: Date): Binary {
 export function getCurrentDateFromCommittedInputs(
   committedInputs: DateCommittedInputs | AgeCommittedInputs,
 ): Date {
-  return convertDateBytesToDate(committedInputs.currentDate)
+  return new Date(committedInputs.currentDateTimestamp * 1000)
 }
-
-export const DEFAULT_DATE_VALUE = new Date(Date.UTC(1111, 10, 11))
 
 export enum ProofType {
   DISCLOSE = 0,

--- a/packages/zkpassport-utils/src/circuits/integrity.ts
+++ b/packages/zkpassport-utils/src/circuits/integrity.ts
@@ -1,4 +1,4 @@
-import { convertDateBytesToDate, ProofData } from ".."
+import { ProofData } from ".."
 
 export function getCommitmentInFromIntegrityProof(proofData: ProofData): bigint {
   return BigInt(proofData.publicInputs[proofData.publicInputs.length - 2])
@@ -9,12 +9,7 @@ export function getCommitmentOutFromIntegrityProof(proofData: ProofData): bigint
 }
 
 export function getCurrentDateFromIntegrityProof(proofData: ProofData): Date {
-  const dateBytes = proofData.publicInputs
-    .slice(0, 8)
-    .map((x) => Number(x) - 48)
-    .map((x) => x.toString())
-  const date = convertDateBytesToDate(dateBytes.join(""))
-  return date
+  return new Date(Number(BigInt(proofData.publicInputs[0])) * 1000)
 }
 
 /**
@@ -22,5 +17,5 @@ export function getCurrentDateFromIntegrityProof(proofData: ProofData): Date {
  * @returns The number of public inputs.
  */
 export function getIntegrityProofPublicInputCount(): number {
-  return 10
+  return 3
 }

--- a/packages/zkpassport-utils/src/recursion.ts
+++ b/packages/zkpassport-utils/src/recursion.ts
@@ -1,4 +1,4 @@
-import { convertDateBytesToDate, getFormattedDate, ProofData } from "."
+import { ProofData } from "."
 
 export type OuterCircuitProof = {
   // The proof as field elements
@@ -23,11 +23,7 @@ export function getOuterCircuitInputs(
   circuitRegistryRoot: string,
 ) {
   const certificateRegistryRoot = cscToDscProof.publicInputs[0]
-  const dateBytes = integrityCheckProof.publicInputs
-    .slice(0, 8)
-    .map((x) => Number(x) - 48)
-    .map((x) => x.toString())
-  const currentDate = convertDateBytesToDate(dateBytes.join(""))
+  const currentDateTimestamp = Number(BigInt(integrityCheckProof.publicInputs[0]))
   const scope = disclosureProofs[0].publicInputs[1]
   const subscope = disclosureProofs[0].publicInputs[2]
   const nullifier = disclosureProofs[0].publicInputs[4]
@@ -36,7 +32,7 @@ export function getOuterCircuitInputs(
   return {
     certificate_registry_root: certificateRegistryRoot,
     circuit_registry_root: circuitRegistryRoot,
-    current_date: getFormattedDate(currentDate),
+    current_date: currentDateTimestamp,
     service_scope: scope,
     service_subscope: subscope,
     param_commitments: paramCommitments,
@@ -89,12 +85,7 @@ export function getCircuitRegistryRootFromOuterProof(proofData: ProofData): bigi
 }
 
 export function getCurrentDateFromOuterProof(proofData: ProofData): Date {
-  const dateBytes = proofData.publicInputs
-    .slice(2, 10)
-    .map((x) => Number(x) - 48)
-    .map((x) => x.toString())
-  const date = convertDateBytesToDate(dateBytes.join(""))
-  return date
+  return new Date(Number(BigInt(proofData.publicInputs[2])) * 1000)
 }
 
 /**
@@ -103,7 +94,7 @@ export function getCurrentDateFromOuterProof(proofData: ProofData): Date {
  * @returns The service scope.
  */
 export function getScopeFromOuterProof(proofData: ProofData): bigint {
-  return BigInt(proofData.publicInputs[10])
+  return BigInt(proofData.publicInputs[3])
 }
 
 /**
@@ -112,7 +103,7 @@ export function getScopeFromOuterProof(proofData: ProofData): bigint {
  * @returns The service subscope.
  */
 export function getSubscopeFromOuterProof(proofData: ProofData): bigint {
-  return BigInt(proofData.publicInputs[11])
+  return BigInt(proofData.publicInputs[4])
 }
 
 /**
@@ -130,5 +121,5 @@ export function getNullifierFromOuterProof(proofData: ProofData): bigint {
  * @returns The param commitments.
  */
 export function getParamCommitmentsFromOuterProof(proofData: ProofData): bigint[] {
-  return proofData.publicInputs.slice(12, proofData.publicInputs.length - 1).map(BigInt)
+  return proofData.publicInputs.slice(5, proofData.publicInputs.length - 1).map(BigInt)
 }

--- a/packages/zkpassport-utils/src/types/index.ts
+++ b/packages/zkpassport-utils/src/types/index.ts
@@ -244,7 +244,7 @@ export type QueryResult = {
 }
 
 export type AgeCommittedInputs = {
-  currentDate: string
+  currentDateTimestamp: number
   minAge: number
   maxAge: number
 }
@@ -254,9 +254,9 @@ export type CountryCommittedInputs = {
 }
 
 export type DateCommittedInputs = {
-  currentDate: string
-  minDate: string
-  maxDate: string
+  currentDateTimestamp: number
+  minDateTimestamp: number
+  maxDateTimestamp: number
 }
 
 export type DiscloseCommittedInputs = {

--- a/packages/zkpassport-utils/src/utils.ts
+++ b/packages/zkpassport-utils/src/utils.ts
@@ -251,6 +251,39 @@ export function formatDate(date: Date | string | number) {
   return date
 }
 
+export function getUnixTimestamp(date: Date | string | number): number {
+  if (typeof date === "string" || typeof date === "number") {
+    return Math.floor(new Date(date).getTime() / 1000)
+  }
+  return Math.floor(date.getTime() / 1000)
+}
+
+export function getTodayTimestamp(): number {
+  const today = Date.UTC(
+    new Date().getUTCFullYear(),
+    new Date().getUTCMonth(),
+    new Date().getUTCDate(),
+    0,
+    0,
+    0,
+    0,
+  )
+
+  return Math.floor(today / 1000)
+}
+
+export function getNowTimestamp(): number {
+  const now = Date.UTC(
+    new Date().getUTCFullYear(),
+    new Date().getUTCMonth(),
+    new Date().getUTCDate(),
+    new Date().getUTCHours(),
+    new Date().getUTCMinutes(),
+    new Date().getUTCSeconds(),
+  )
+  return Math.floor(now / 1000)
+}
+
 export function formatQueryResultDates(queryResult: QueryResult) {
   // Iterate over the query result and format the dates
   for (const key in queryResult) {

--- a/packages/zkpassport-utils/tests/circuit-matcher.test.ts
+++ b/packages/zkpassport-utils/tests/circuit-matcher.test.ts
@@ -1,4 +1,3 @@
-import { format, formatDate } from "date-fns"
 import { Alpha3Code } from "i18n-iso-countries"
 import {
   calculateAge,
@@ -24,7 +23,12 @@ import {
 } from "../src/circuit-matcher"
 import { getCountryWeightedSum } from "../src/circuits/country"
 import { HashAlgorithm, PackagedCertificate, Query } from "../src/types"
-import { rightPadArrayWithZeros, rightPadCountryCodeArray } from "../src/utils"
+import {
+  getNowTimestamp,
+  getUnixTimestamp,
+  rightPadArrayWithZeros,
+  rightPadCountryCodeArray,
+} from "../src/utils"
 import rootCerts from "./fixtures/root-certs.json"
 import { PASSPORTS } from "./fixtures/passports"
 import * as fs from "fs"
@@ -318,10 +322,10 @@ describe("Circuit Matcher - RSA", () => {
   })
 
   it("should get the right integrity check circuit inputs", async () => {
-    const result = await getIntegrityCheckCircuitInputs(PASSPORTS.john, 1n, 1n)
+    const timestamp = getNowTimestamp()
+    const result = await getIntegrityCheckCircuitInputs(PASSPORTS.john, 1n, 1n, timestamp)
     expect(result).toEqual({
-      current_date: formatDate(new Date(), "yyyyMMdd"),
-      timestamp: Math.floor(Date.now() / 1000),
+      current_date: timestamp,
       dg1: rightPadArrayWithZeros(PASSPORTS.john.dataGroups[0].value, 95),
       signed_attributes: rightPadArrayWithZeros(
         PASSPORTS.john.sod.signerInfo.signedAttrs.bytes.toNumberArray(),
@@ -391,10 +395,11 @@ describe("Circuit Matcher - RSA", () => {
     const query: Query = {
       age: { gte: 18 },
     }
-    const result = await getAgeCircuitInputs(PASSPORTS.john, query, 1n, 2n, 3n)
+    const timestamp = getNowTimestamp()
+    const result = await getAgeCircuitInputs(PASSPORTS.john, query, 1n, 2n, 3n, timestamp)
     expect(result).toEqual({
       dg1: rightPadArrayWithZeros(PASSPORTS.john.dataGroups[0].value, 95),
-      current_date: format(new Date(), "yyyyMMdd"),
+      current_date: timestamp,
       comm_in: "0x0c8b1e3be3cbbe1aa1bdbb8d25856aa3fd9af160cd1704a03154b2a67222c65b",
       private_nullifier: "0x25d736ccb33e663ca64bf23add154cb740c5fa863b518da3c1a584f856b48986",
       service_scope: "0x2",
@@ -478,17 +483,18 @@ describe("Circuit Matcher - RSA", () => {
     const query: Query = {
       birthdate: { gte: new Date("1980-01-01"), lte: new Date("1990-01-01") },
     }
-    const result = await getBirthdateCircuitInputs(PASSPORTS.john, query, 1n, 2n, 3n)
+    const timestamp = getNowTimestamp()
+    const result = await getBirthdateCircuitInputs(PASSPORTS.john, query, 1n, 2n, 3n, timestamp)
     expect(result).toEqual({
       dg1: rightPadArrayWithZeros(PASSPORTS.john.dataGroups[0].value, DG1_INPUT_SIZE),
-      current_date: format(new Date(), "yyyyMMdd"),
+      current_date: timestamp,
       comm_in: "0x0c8b1e3be3cbbe1aa1bdbb8d25856aa3fd9af160cd1704a03154b2a67222c65b",
       private_nullifier: "0x25d736ccb33e663ca64bf23add154cb740c5fa863b518da3c1a584f856b48986",
       service_scope: "0x2",
       service_subscope: "0x3",
       salt: "0x1",
-      min_date: "19800101",
-      max_date: "19900101",
+      min_date: getUnixTimestamp(new Date("1980-01-01")),
+      max_date: getUnixTimestamp(new Date("1990-01-01")),
     })
   })
 
@@ -496,17 +502,18 @@ describe("Circuit Matcher - RSA", () => {
     const query: Query = {
       expiry_date: { gte: new Date("2025-01-01"), lte: new Date("2035-12-31") },
     }
-    const result = await getExpiryDateCircuitInputs(PASSPORTS.john, query, 1n, 2n, 3n)
+    const timestamp = getNowTimestamp()
+    const result = await getExpiryDateCircuitInputs(PASSPORTS.john, query, 1n, 2n, 3n, timestamp)
     expect(result).toEqual({
       dg1: rightPadArrayWithZeros(PASSPORTS.john.dataGroups[0].value, DG1_INPUT_SIZE),
-      current_date: format(new Date(), "yyyyMMdd"),
+      current_date: timestamp,
       comm_in: "0x0c8b1e3be3cbbe1aa1bdbb8d25856aa3fd9af160cd1704a03154b2a67222c65b",
       private_nullifier: "0x25d736ccb33e663ca64bf23add154cb740c5fa863b518da3c1a584f856b48986",
       service_scope: "0x2",
       service_subscope: "0x3",
       salt: "0x1",
-      min_date: "20250101",
-      max_date: "20351231",
+      min_date: getUnixTimestamp(new Date("2025-01-01")),
+      max_date: getUnixTimestamp(new Date("2035-12-31")),
     })
   })
 })
@@ -618,10 +625,10 @@ describe("Circuit Matcher - ECDSA", () => {
   })
 
   it("should get the right integrity check circuit inputs", async () => {
-    const result = await getIntegrityCheckCircuitInputs(PASSPORTS.mary, 1n, 1n)
+    const timestamp = getNowTimestamp()
+    const result = await getIntegrityCheckCircuitInputs(PASSPORTS.mary, 1n, 1n, timestamp)
     expect(result).toEqual({
-      current_date: formatDate(new Date(), "yyyyMMdd"),
-      timestamp: Math.floor(Date.now() / 1000),
+      current_date: timestamp,
       dg1: rightPadArrayWithZeros(PASSPORTS.mary.dataGroups[0].value, DG1_INPUT_SIZE),
       signed_attributes: rightPadArrayWithZeros(
         PASSPORTS.mary.sod.signerInfo.signedAttrs.bytes.toNumberArray(),
@@ -691,10 +698,11 @@ describe("Circuit Matcher - ECDSA", () => {
     const query: Query = {
       age: { gte: 18 },
     }
-    const result = await getAgeCircuitInputs(PASSPORTS.mary, query, 1n, 2n, 3n)
+    const timestamp = getNowTimestamp()
+    const result = await getAgeCircuitInputs(PASSPORTS.mary, query, 1n, 2n, 3n, timestamp)
     expect(result).toEqual({
       dg1: rightPadArrayWithZeros(PASSPORTS.mary.dataGroups[0].value, DG1_INPUT_SIZE),
-      current_date: format(new Date(), "yyyyMMdd"),
+      current_date: timestamp,
       comm_in: "0x1dcf5c2b156d3c87f57853183dd6afd108cfb59edacfd872925f6daafba0b331",
       private_nullifier: "0x114650503358000aedd93c72f5f7b71018e26110dce3aec53760e59dfd722d5b",
       service_scope: "0x2",
@@ -778,17 +786,18 @@ describe("Circuit Matcher - ECDSA", () => {
     const query: Query = {
       birthdate: { gte: new Date("1980-01-01"), lte: new Date("1990-01-01") },
     }
-    const result = await getBirthdateCircuitInputs(PASSPORTS.mary, query, 1n, 2n, 3n)
+    const timestamp = getNowTimestamp()
+    const result = await getBirthdateCircuitInputs(PASSPORTS.mary, query, 1n, 2n, 3n, timestamp)
     expect(result).toEqual({
       dg1: rightPadArrayWithZeros(PASSPORTS.mary.dataGroups[0].value, DG1_INPUT_SIZE),
-      current_date: format(new Date(), "yyyyMMdd"),
+      current_date: timestamp,
       comm_in: "0x1dcf5c2b156d3c87f57853183dd6afd108cfb59edacfd872925f6daafba0b331",
       private_nullifier: "0x114650503358000aedd93c72f5f7b71018e26110dce3aec53760e59dfd722d5b",
       service_scope: "0x2",
       service_subscope: "0x3",
       salt: "0x1",
-      min_date: "19800101",
-      max_date: "19900101",
+      min_date: getUnixTimestamp(new Date("1980-01-01")),
+      max_date: getUnixTimestamp(new Date("1990-01-01")),
     })
   })
 
@@ -796,17 +805,18 @@ describe("Circuit Matcher - ECDSA", () => {
     const query: Query = {
       expiry_date: { gte: new Date("2025-01-01"), lte: new Date("2035-12-31") },
     }
-    const result = await getExpiryDateCircuitInputs(PASSPORTS.mary, query, 1n, 2n, 3n)
+    const timestamp = getNowTimestamp()
+    const result = await getExpiryDateCircuitInputs(PASSPORTS.mary, query, 1n, 2n, 3n, timestamp)
     expect(result).toEqual({
       dg1: rightPadArrayWithZeros(PASSPORTS.mary.dataGroups[0].value, DG1_INPUT_SIZE),
-      current_date: format(new Date(), "yyyyMMdd"),
+      current_date: timestamp,
       comm_in: "0x1dcf5c2b156d3c87f57853183dd6afd108cfb59edacfd872925f6daafba0b331",
       private_nullifier: "0x114650503358000aedd93c72f5f7b71018e26110dce3aec53760e59dfd722d5b",
       service_scope: "0x2",
       service_subscope: "0x3",
       salt: "0x1",
-      min_date: "20250101",
-      max_date: "20351231",
+      min_date: getUnixTimestamp(new Date("2025-01-01")),
+      max_date: getUnixTimestamp(new Date("2035-12-31")),
     })
   })
 })


### PR DESCRIPTION
This PR replaces all date strings used as inputs to the circuit with a Unix timestamps (to the second)