### PR TITLE
fix: add validTo >= validFrom validation in batchUpdateRoots

### DIFF
--- a/packages/registry-contracts/src/CertificateRegistry.sol
+++ b/packages/registry-contracts/src/CertificateRegistry.sol
@@ -178,6 +178,7 @@ contract CertificateRegistry {
             // Ensure validTo is non-zero unless it's the last root
             if (i < roots.length - 1) {
                 require(rootInput.validTo != 0, "Root validTo cannot be zero unless it's the last root");
+                require(rootInput.validTo >= rootInput.validFrom, "Root validTo must be >= validFrom");
             }
 
             // Increment root count and store index mapping

--- a/packages/registry-contracts/src/CircuitRegistry.sol
+++ b/packages/registry-contracts/src/CircuitRegistry.sol
@@ -178,6 +178,7 @@ contract CircuitRegistry {
             // Ensure validTo is non-zero unless it's the last root
             if (i < roots.length - 1) {
                 require(rootInput.validTo != 0, "Root validTo cannot be zero unless it's the last root");
+                require(rootInput.validTo >= rootInput.validFrom, "Root validTo must be >= validFrom");
             }
 
             // Increment root count and store index mapping


### PR DESCRIPTION
Add missing interval validation to prevent invalid time ranges in batch root updates.

- CertificateRegistry: Add validTo >= validFrom check for non-last roots
- CircuitRegistry: Add validTo >= validFrom check for non-last roots

This prevents roots with inverted validity periods from being imported in batch operations.