### PR TITLE
feat(utils): Set custom epoch for birthdate proof timestamps

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -95,7 +95,7 @@
     },
     "packages/zkpassport-utils": {
       "name": "@zkpassport/utils",
-      "version": "0.22.1",
+      "version": "0.22.2",
       "dependencies": {
         "@lapo/asn1js": "^2.0.4",
         "@noble/ciphers": "^1.0.0",

--- a/packages/zkpassport-sdk/src/index.ts
+++ b/packages/zkpassport-sdk/src/index.ts
@@ -71,6 +71,8 @@ import {
   FacematchMode,
   SanctionsCountries,
   SanctionsLists,
+  getBirthdateMinDateTimestamp,
+  getBirthdateMaxDateTimestamp,
 } from "@zkpassport/utils"
 import { bytesToHex, numberToBytesBE } from "@noble/ciphers/utils"
 import { noLogger as logger } from "./logger"

--- a/packages/zkpassport-sdk/src/index.ts
+++ b/packages/zkpassport-sdk/src/index.ts
@@ -1331,10 +1331,10 @@ export class ZKPassport {
       0,
       0,
     )
-    const minDate = getMinDateFromCommittedInputs(
+    const minDate = getBirthdateMinDateTimestamp(
       proof.committedInputs?.compare_birthdate as DateCommittedInputs,
     )
-    const maxDate = getMaxDateFromCommittedInputs(
+    const maxDate = getBirthdateMaxDateTimestamp(
       proof.committedInputs?.compare_birthdate as DateCommittedInputs,
     )
     const currentDate = getCurrentDateFromCommittedInputs(
@@ -3030,7 +3030,7 @@ export class ZKPassport {
             .join("")
       } else if (circuitName === "compare_age_evm") {
         const value = proof.committedInputs[circuitName] as AgeCommittedInputs
-        const currentDateBytes = Array.from(numberToBytesBE(value.currentDateTimestamp, 4))
+        const currentDateBytes = Array.from(numberToBytesBE(value.currentDateTimestamp, 8))
         compressedCommittedInputs =
           ProofType.AGE.toString(16).padStart(2, "0") +
           currentDateBytes.map((x) => x.toString(16).padStart(2, "0")).join("") +
@@ -3038,9 +3038,9 @@ export class ZKPassport {
           value.maxAge.toString(16).padStart(2, "0")
       } else if (circuitName === "compare_birthdate_evm") {
         const value = proof.committedInputs[circuitName] as DateCommittedInputs
-        const currentDateBytes = Array.from(numberToBytesBE(value.currentDateTimestamp, 4))
-        const minDateBytes = Array.from(numberToBytesBE(value.minDateTimestamp, 4))
-        const maxDateBytes = Array.from(numberToBytesBE(value.maxDateTimestamp, 4))
+        const currentDateBytes = Array.from(numberToBytesBE(value.currentDateTimestamp, 8))
+        const minDateBytes = Array.from(numberToBytesBE(value.minDateTimestamp, 8))
+        const maxDateBytes = Array.from(numberToBytesBE(value.maxDateTimestamp, 8))
         compressedCommittedInputs =
           ProofType.BIRTHDATE.toString(16).padStart(2, "0") +
           currentDateBytes.map((x) => x.toString(16).padStart(2, "0")).join("") +
@@ -3048,9 +3048,9 @@ export class ZKPassport {
           maxDateBytes.map((x) => x.toString(16).padStart(2, "0")).join("")
       } else if (circuitName === "compare_expiry_evm") {
         const value = proof.committedInputs[circuitName] as DateCommittedInputs
-        const currentDateBytes = Array.from(numberToBytesBE(value.currentDateTimestamp, 4))
-        const minDateBytes = Array.from(numberToBytesBE(value.minDateTimestamp, 4))
-        const maxDateBytes = Array.from(numberToBytesBE(value.maxDateTimestamp, 4))
+        const currentDateBytes = Array.from(numberToBytesBE(value.currentDateTimestamp, 8))
+        const minDateBytes = Array.from(numberToBytesBE(value.minDateTimestamp, 8))
+        const maxDateBytes = Array.from(numberToBytesBE(value.maxDateTimestamp, 8))
         compressedCommittedInputs =
           ProofType.EXPIRY_DATE.toString(16).padStart(2, "0") +
           currentDateBytes.map((x) => x.toString(16).padStart(2, "0")).join("") +

--- a/packages/zkpassport-utils/package.json
+++ b/packages/zkpassport-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkpassport/utils",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "type": "module",
   "main": "./dist/esm/index.js",
   "types": "./dist/esm/index.d.ts",

--- a/packages/zkpassport-utils/src/circuit-matcher.ts
+++ b/packages/zkpassport-utils/src/circuit-matcher.ts
@@ -11,6 +11,7 @@ import {
   hashSaltCountrySignedAttrDg1EContentPrivateNullifier,
   hashSaltCountryTbs,
   hashSaltDg1PrivateNullifier,
+  SECONDS_BETWEEN_1900_AND_1970,
 } from "./circuits"
 import { parseDate } from "./circuits/disclose"
 import type { DigestAlgorithm } from "./cms/types"
@@ -1062,8 +1063,11 @@ export async function getBirthdateCircuitInputs(
     service_scope: `0x${service_scope.toString(16)}`,
     service_subscope: `0x${service_subscope.toString(16)}`,
     salt: `0x${salt.toString(16)}`,
-    min_date: minDate ? getUnixTimestamp(minDate) : 0,
-    max_date: maxDate ? getUnixTimestamp(maxDate) : 0,
+    // Add the seconds between 1900 and 1970 to the date to get the correct date
+    // This is because the circuit expects the epoch to be 1900 rather than 1970
+    // for min_date and max_date
+    min_date: minDate ? getUnixTimestamp(minDate) + SECONDS_BETWEEN_1900_AND_1970 : 0,
+    max_date: maxDate ? getUnixTimestamp(maxDate) + SECONDS_BETWEEN_1900_AND_1970 : 0,
   }
 }
 

--- a/packages/zkpassport-utils/src/circuits/age.ts
+++ b/packages/zkpassport-utils/src/circuits/age.ts
@@ -55,7 +55,7 @@ export async function getAgeEVMParameterCommitment(
   maxAge: number,
 ): Promise<bigint> {
   const hash = sha256(
-    new Uint8Array([ProofType.AGE, ...numberToBytesBE(currentDateTimestamp, 4), minAge, maxAge]),
+    new Uint8Array([ProofType.AGE, ...numberToBytesBE(currentDateTimestamp, 8), minAge, maxAge]),
   )
   const hashBigInt = packBeBytesIntoField(hash, 31)
   return hashBigInt

--- a/packages/zkpassport-utils/src/circuits/index.ts
+++ b/packages/zkpassport-utils/src/circuits/index.ts
@@ -189,11 +189,11 @@ export function getNumberOfPublicInputs(circuitName: string) {
 export function getCommittedInputCount(circuitName: DisclosureCircuitName) {
   switch (circuitName) {
     case "compare_age_evm":
-      return 7
+      return 11
     case "compare_birthdate_evm":
-      return 13
+      return 25
     case "compare_expiry_evm":
-      return 13
+      return 25
     case "disclose_bytes_evm":
       return 181
     case "inclusion_check_issuing_country_evm":

--- a/packages/zkpassport-utils/src/utils.ts
+++ b/packages/zkpassport-utils/src/utils.ts
@@ -253,9 +253,13 @@ export function formatDate(date: Date | string | number) {
 
 export function getUnixTimestamp(date: Date | string | number): number {
   if (typeof date === "string" || typeof date === "number") {
-    return Math.floor(new Date(date).getTime() / 1000)
+    const timestamp = Math.floor(new Date(date).getTime() / 1000)
+    // Adds 1 second to the timestamp as 0 is the ignored value for the date proof
+    return timestamp === 0 ? timestamp + 1 : timestamp
   }
-  return Math.floor(date.getTime() / 1000)
+  const timestamp = Math.floor(date.getTime() / 1000)
+  // Adds 1 second to the timestamp as 0 is the ignored value for the date proof
+  return timestamp === 0 ? timestamp + 1 : timestamp
 }
 
 export function getTodayTimestamp(): number {

--- a/packages/zkpassport-utils/tests/circuit-matcher.test.ts
+++ b/packages/zkpassport-utils/tests/circuit-matcher.test.ts
@@ -40,6 +40,7 @@ import {
   getDSCSignatureHashAlgorithm,
   SIGNED_ATTR_INPUT_SIZE,
   E_CONTENT_INPUT_SIZE,
+  SECONDS_BETWEEN_1900_AND_1970,
 } from "../src"
 import { DSC } from "../src/passport/dsc"
 import { AsnParser } from "@peculiar/asn1-schema"
@@ -487,8 +488,8 @@ describe("Circuit Matcher - RSA", () => {
       service_scope: "0x2",
       service_subscope: "0x3",
       salt: "0x1",
-      min_date: getUnixTimestamp(new Date("1980-01-01")),
-      max_date: getUnixTimestamp(new Date("1990-01-01")),
+      min_date: getUnixTimestamp(new Date("1980-01-01")) + SECONDS_BETWEEN_1900_AND_1970,
+      max_date: getUnixTimestamp(new Date("1990-01-01")) + SECONDS_BETWEEN_1900_AND_1970,
     })
   })
 
@@ -784,8 +785,8 @@ describe("Circuit Matcher - ECDSA", () => {
       service_scope: "0x2",
       service_subscope: "0x3",
       salt: "0x1",
-      min_date: getUnixTimestamp(new Date("1980-01-01")),
-      max_date: getUnixTimestamp(new Date("1990-01-01")),
+      min_date: getUnixTimestamp(new Date("1980-01-01")) + SECONDS_BETWEEN_1900_AND_1970,
+      max_date: getUnixTimestamp(new Date("1990-01-01")) + SECONDS_BETWEEN_1900_AND_1970,
     })
   })
 


### PR DESCRIPTION
This PR adds support for the custom timestamps used by the birthdate circuit. 

Since the usual epoch is 1970 and the circuit do not support negative numbers as inputs, and considering birthdates can be before 1970, the birthdate circuit now assumes the epoch is 1900 rather than 1970 for the minimum date and maximum date. So, the conversion from timestamps starting in 1900 to JavaScript Date objects using the regular 1970 Unix epoch is done internally in the utils library to reflect this. Allowing the external interface in the SDK to remain untouched, with both dates before and after 1970 specifiable for birthdate date range checks. 

Other dates, such as the current date or expiry date range dates still use 1970 as the epoch, since they have no reason to be before 1970. 

Note: to account for potentially larger timestamps due to the epoch starting in 1900, the timestamp is now encoded on 8 bytes (u64) rather than 4 bytes (u32). Otherwise, the timestamp would have started to overflow in a few years with an epoch starting in 1900.