### PR TITLE
chore(registry-sdk): Update IPFS links to use Pinata gateway

### DIFF
--- a/packages/registry-sdk/src/constants.ts
+++ b/packages/registry-sdk/src/constants.ts
@@ -26,7 +26,7 @@ export const PACKAGED_CERTIFICATES_URL_DEV = "http://localhost:3000/certificates
  */
 export const PACKAGED_CERTIFICATES_URL_TEMPLATE = (chainId: number, root: string, cid?: string) => {
   if (cid) {
-    return `https://ipfs.infura.io/ipfs/${cid}`
+    return `https://ipfs.zkpassport.id/ipfs/${cid}`
   }
   root = normaliseHash(root)
   if (chainId === 1) {
@@ -74,7 +74,7 @@ export const CIRCUIT_MANIFEST_URL_TEMPLATE = (
       return `${CIRCUIT_URL_DEV}/by-version/${version}/manifest.json`
     }
   } else if (cid) {
-    return `https://ipfs.infura.io/ipfs/${cid}`
+    return `https://ipfs.zkpassport.id/ipfs/${cid}`
   } else {
     throw new Error("No root, version or cid provided")
   }
@@ -88,7 +88,7 @@ export const CIRCUIT_MANIFEST_URL_TEMPLATE = (
  */
 export const PACKAGED_CIRCUIT_URL_TEMPLATE = (chainId: number, hash: string, cid?: string) => {
   if (cid) {
-    return `https://ipfs.infura.io/ipfs/${cid}`
+    return `https://ipfs.zkpassport.id/ipfs/${cid}`
   }
   hash = normaliseHash(hash)
   if (chainId === 1) {


### PR DESCRIPTION
Update IPFS endpoints to use the Pinata gateway `ipfs.zkpassport.id` instead of `ipfs.infura.io`.

---
Linear Issue: [ZKP-578](https://linear.app/obsidion/issue/ZKP-578/update-ipfs-endpoints-to-use-the-pinata-gateway)

<a href="https://cursor.com/background-agent?bcId=bc-5b225197-02ad-4da7-9276-3499e892cfd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5b225197-02ad-4da7-9276-3499e892cfd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

