### PR TITLE
feat(sdk): cache server verify resources and add warmup API

### DIFF
--- a/packages/zkpassport-sdk/src/index.ts
+++ b/packages/zkpassport-sdk/src/index.ts
@@ -24,12 +24,17 @@ import {
 import { noLogger as logger } from "./logger"
 import i18en from "i18n-iso-countries/langs/en.json"
 import { Buffer } from "buffer/"
-import { RegistryClient } from "@zkpassport/registry"
 import { Bridge, BridgeInterface } from "@obsidion/bridge"
 import { QueryBuilder, QueryResultErrors } from "./types"
 import { PublicInputChecker } from "./public-input-checker"
 import { SolidityVerifier } from "./solidity-verifier"
 import { DEFAULT_VALIDITY, VERSION } from "./constants"
+import {
+  getCachedCircuitManifest,
+  getCachedPackagedCircuit,
+  getCachedVerifierBackend,
+  warmupVerificationResources,
+} from "./verification-resources"
 
 // If Buffer is not defined, then we use the Buffer from the buffer package
 if (typeof globalThis.Buffer === "undefined") {
@@ -180,6 +185,28 @@ export class ZKPassport {
       throw new Error("Domain argument is required in Node.js environment")
     }
     this.domain = this.normalizeDomain(_domain || window.location.hostname)
+  }
+
+  /**
+   * Preload the verifier backend and optional registry-backed circuit metadata.
+   *
+   * This is primarily useful for server runtimes that want to remove the cold-start
+   * cost from the first verification request.
+   */
+  public static async warmupVerification({
+    version,
+    writingDirectory,
+    circuitNames,
+  }: {
+    version?: string
+    writingDirectory?: string
+    circuitNames?: string[]
+  } = {}) {
+    await warmupVerificationResources({
+      version,
+      writingDirectory,
+      circuitNames,
+    })
   }
 
   private async handleResult(topic: string) {
@@ -549,15 +576,11 @@ export class ZKPassport {
     }
     const formattedResult: QueryResult = formatQueryResultDates(queryResult)
 
-    const { UltraHonkVerifierBackend } = await import("@aztec/bb.js")
     // Automatically set the writing directory to `/tmp` if it is not provided
     // and the code is not running in the browser
     if (typeof window === "undefined" && !writingDirectory) {
       writingDirectory = "/tmp"
     }
-    const verifier = new UltraHonkVerifierBackend({
-      crsPath: writingDirectory ? writingDirectory + "/.bb-crs" : undefined,
-    })
     let verified = true
     let uniqueIdentifier: string | undefined
     let uniqueIdentifierType: NullifierType | undefined
@@ -595,22 +618,22 @@ export class ZKPassport {
     }
     // Only proceed with the proof verification if the public inputs are correct
     if (verified) {
-      const registryClient = new RegistryClient({ chainId: 11155111 })
-      const circuitManifest = await registryClient.getCircuitManifest(undefined, {
+      const verifier = await getCachedVerifierBackend(writingDirectory)
+      const circuitManifest = await getCachedCircuitManifest(
         // We assume all proofs have the same version
-        version: proofs[0].version,
-      })
+        proofs[0].version,
+      )
       for (const proof of proofs) {
         const isOuterEVM = proof.name?.startsWith("outer_evm_")
         const proofName = proof.name!
         const proofData = getProofData(proof.proof as string, getNumberOfPublicInputs(proofName))
-        const hostedPackagedCircuit = await registryClient.getPackagedCircuit(
+        const hostedPackagedCircuit = await getCachedPackagedCircuit(
           proofName,
           circuitManifest,
           // TODO: set to always validate when the issue is vkey hash calculation is fixed
           // Not as important anyway, as the solidity verifier is the ultimate anchor for
           // EVM outer proofs verification
-          { validate: !isOuterEVM },
+          !isOuterEVM,
         )
         if (isOuterEVM) {
           try {

--- a/packages/zkpassport-sdk/src/public-input-checker.ts
+++ b/packages/zkpassport-sdk/src/public-input-checker.ts
@@ -65,7 +65,6 @@ import {
   getServiceSubScopeFromDisclosureProof,
 } from "@zkpassport/utils"
 import { QueryResultErrors } from "./types"
-import { RegistryClient } from "@zkpassport/registry"
 import {
   APPLE_APP_ATTEST_ROOT_KEY_HASH,
   DEFAULT_DATE_VALUE,
@@ -75,6 +74,7 @@ import {
   ZKPASSPORT_ANDROID_APP_ID_HASH,
   ZKPASSPORT_IOS_APP_ID_HASH,
 } from "./constants"
+import { getCachedRootValidity } from "./verification-resources"
 
 export class PublicInputChecker {
   public static checkDiscloseBytesPublicInputs(proof: ProofResult, queryResult: QueryResult) {
@@ -1089,10 +1089,7 @@ export class PublicInputChecker {
   ) {
     let isCorrect = true
     try {
-      // Maintained certificate registry settled onchain
-      // Here we use Ethereum Sepolia
-      const registryClient = new RegistryClient({ chainId: 11155111 })
-      const isValid = await registryClient.isCertificateRootValid(root)
+      const isValid = await getCachedRootValidity("certificate", root)
       if (!isValid) {
         console.warn("The ID was signed by an unrecognized root certificate")
         isCorrect = false
@@ -1124,8 +1121,7 @@ export class PublicInputChecker {
   public static async checkCircuitRegistryRoot(root: string, queryResultErrors: any) {
     let isCorrect = true
     try {
-      const registryClient = new RegistryClient({ chainId: 11155111 })
-      const isValid = await registryClient.isCircuitRootValid(root)
+      const isValid = await getCachedRootValidity("circuit", root)
       if (!isValid) {
         console.warn("The proof uses unrecognized circuits")
         isCorrect = false

--- a/packages/zkpassport-sdk/src/verification-resources.ts
+++ b/packages/zkpassport-sdk/src/verification-resources.ts
@@ -1,0 +1,129 @@
+import type { CircuitManifest, PackagedCircuit } from "@zkpassport/utils"
+
+import { RegistryClient } from "@zkpassport/registry"
+
+type UltraHonkVerifierBackend = import("@aztec/bb.js").UltraHonkVerifierBackend
+
+const DEFAULT_VERIFIER_CACHE_KEY = "__default__"
+const LATEST_VERSION_CACHE_KEY = "__latest__"
+const ROOT_VALIDITY_TTL_MS = 5 * 60 * 1000
+const SEPOLIA_CHAIN_ID = 11155111
+
+const verifierCache = new Map<string, Promise<UltraHonkVerifierBackend>>()
+const manifestCache = new Map<string, Promise<CircuitManifest>>()
+const packagedCircuitCache = new Map<string, Promise<PackagedCircuit>>()
+const rootValidityCache = new Map<string, { expiresAt: number; valid: boolean }>()
+
+let registryClient: RegistryClient | undefined
+
+function getRegistryClient() {
+  registryClient ??= new RegistryClient({ chainId: SEPOLIA_CHAIN_ID })
+  return registryClient
+}
+
+export async function getCachedVerifierBackend(
+  writingDirectory?: string,
+): Promise<UltraHonkVerifierBackend> {
+  const crsPath = writingDirectory ? `${writingDirectory}/.bb-crs` : undefined
+  const cacheKey = crsPath ?? DEFAULT_VERIFIER_CACHE_KEY
+
+  let promise = verifierCache.get(cacheKey)
+  if (!promise) {
+    promise = (async () => {
+      const { UltraHonkVerifierBackend } = await import("@aztec/bb.js")
+      return new UltraHonkVerifierBackend({
+        crsPath,
+      })
+    })()
+    verifierCache.set(cacheKey, promise)
+    promise.catch(() => verifierCache.delete(cacheKey))
+  }
+
+  return promise!
+}
+
+export async function getCachedCircuitManifest(version?: string): Promise<CircuitManifest> {
+  const cacheKey = version ?? LATEST_VERSION_CACHE_KEY
+
+  let promise = manifestCache.get(cacheKey)
+  if (!promise) {
+    promise = getRegistryClient().getCircuitManifest(undefined, { version })
+    manifestCache.set(cacheKey, promise)
+    promise.catch(() => manifestCache.delete(cacheKey))
+  }
+
+  return promise!
+}
+
+export async function getCachedPackagedCircuit(
+  circuitName: string,
+  manifest: CircuitManifest,
+  validate: boolean,
+): Promise<PackagedCircuit> {
+  const cacheKey = `${manifest.root}:${circuitName}:${validate ? "validated" : "raw"}`
+
+  let promise = packagedCircuitCache.get(cacheKey)
+  if (!promise) {
+    promise = getRegistryClient().getPackagedCircuit(circuitName, manifest, {
+      validate,
+    })
+    packagedCircuitCache.set(cacheKey, promise)
+    promise.catch(() => packagedCircuitCache.delete(cacheKey))
+  }
+
+  return promise!
+}
+
+export async function getCachedRootValidity(
+  type: "certificate" | "circuit",
+  root: string,
+): Promise<boolean> {
+  const cacheKey = `${type}:${root}`
+  const cached = rootValidityCache.get(cacheKey)
+  if (cached && Date.now() < cached.expiresAt) {
+    return cached.valid
+  }
+
+  const valid =
+    type === "certificate"
+      ? await getRegistryClient().isCertificateRootValid(root)
+      : await getRegistryClient().isCircuitRootValid(root)
+
+  rootValidityCache.set(cacheKey, {
+    valid,
+    expiresAt: Date.now() + ROOT_VALIDITY_TTL_MS,
+  })
+
+  return valid
+}
+
+export async function warmupVerificationResources({
+  version,
+  writingDirectory,
+  circuitNames = [],
+}: {
+  version?: string
+  writingDirectory?: string
+  circuitNames?: string[]
+} = {}): Promise<void> {
+  getRegistryClient()
+
+  const verifierPromise = getCachedVerifierBackend(writingDirectory)
+  if (!version) {
+    await verifierPromise
+    return
+  }
+
+  const manifest = await getCachedCircuitManifest(version)
+  await verifierPromise
+
+  if (circuitNames.length === 0) {
+    return
+  }
+
+  await Promise.all(
+    circuitNames.map((circuitName) =>
+      getCachedPackagedCircuit(circuitName, manifest, !circuitName.startsWith("outer_evm_")),
+    ),
+  )
+}


### PR DESCRIPTION
## Summary
- cache verifier backends by CRS path instead of constructing one per `verify()` call
- cache the registry client, circuit manifests, packaged circuits, and root validity lookups
- add `ZKPassport.warmupVerification(...)` for server runtimes that want to remove cold-start cost
- keep verification semantics and error handling in the SDK rather than reimplementing them downstream

## Why
A downstream app needed server-side reuse to avoid the cold-start and repeated network overhead of calling `ZKPassport.verify()` on every passport submission. The alternative there was a local verifier fork, but that immediately started to drift from SDK behavior and surfaced review issues around skipped proof verification and exception handling. This change keeps the optimization in the SDK, which is the correct ownership boundary.

## Notes
- regular and EVM outer-proof handling stays on the existing SDK paths
- registry lookup failures are still treated as verification failures; they now just reuse a cached client/root lookup