### PR TITLE
feat(sdk): Send proof data to API after successful verification

### DIFF
--- a/packages/zkpassport-sdk/src/constants.ts
+++ b/packages/zkpassport-sdk/src/constants.ts
@@ -2,6 +2,8 @@ export const VERSION = "0.12.0"
 export const DEFAULT_VALIDITY = 7 * 24 * 60 * 60 // 7 days
 export const DEFAULT_DATE_VALUE = new Date(0)
 
+export const DASHBOARD_API_BASE_URL = "https://dashboard-api.zkpassport.id"
+
 // This is the app id hash for the ZKPassport app
 // i.e. hash of `YL5MS3Z639.app.zkpassport.zkpassport`
 export const ZKPASSPORT_IOS_APP_ID_HASH =

--- a/packages/zkpassport-sdk/src/dashboard-api.ts
+++ b/packages/zkpassport-sdk/src/dashboard-api.ts
@@ -3,21 +3,17 @@ import { DASHBOARD_API_BASE_URL, VERSION } from "./constants"
 import { noLogger as logger } from "./logger"
 
 export async function submitProof({
-  projectId,
   domain,
   proofs,
   queryResult,
   uniqueIdentifier,
   scope,
-  apiUrl,
 }: {
-  projectId: string
   domain: string
   proofs: Array<ProofResult>
   queryResult: QueryResult
   uniqueIdentifier: string | undefined
   scope: string | undefined
-  apiUrl?: string
 }) {
   const payload = proofs.map((p) => ({
     proof: p.proof,
@@ -29,11 +25,10 @@ export async function submitProof({
     committedInputs: p.committedInputs,
   }))
   try {
-    const response = await fetch(apiUrl ?? `${DASHBOARD_API_BASE_URL}/proofs`, {
+    const response = await fetch(`${DASHBOARD_API_BASE_URL}/proofs`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        projectId,
         domain,
         proofs: payload,
         queryResult,

--- a/packages/zkpassport-sdk/src/dashboard-api.ts
+++ b/packages/zkpassport-sdk/src/dashboard-api.ts
@@ -1,0 +1,51 @@
+import type { ProofResult, QueryResult } from "@zkpassport/utils"
+import { DASHBOARD_API_BASE_URL, VERSION } from "./constants"
+import { noLogger as logger } from "./logger"
+
+export async function submitProof({
+  projectId,
+  domain,
+  proofs,
+  queryResult,
+  uniqueIdentifier,
+  scope,
+}: {
+  projectId: string
+  domain: string
+  proofs: Array<ProofResult>
+  queryResult: QueryResult
+  uniqueIdentifier: string | undefined
+  scope: string | undefined
+}) {
+  const payload = proofs.map((p) => ({
+    proof: p.proof,
+    vkeyHash: p.vkeyHash,
+    version: p.version,
+    name: p.name,
+    index: p.index,
+    total: p.total,
+    committedInputs: p.committedInputs,
+  }))
+  try {
+    const response = await fetch(`${DASHBOARD_API_BASE_URL}/proofs`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        projectId,
+        domain,
+        proofs: payload,
+        queryResult,
+        uniqueIdentifier,
+        scope,
+        sdkVersion: VERSION,
+      }),
+    })
+    if (!response.ok) {
+      logger.warn("API request failed with status:", response.status)
+    } else {
+      logger.debug("API response status:", response.status)
+    }
+  } catch (e) {
+    logger.warn("API call failed:", e)
+  }
+}

--- a/packages/zkpassport-sdk/src/dashboard-api.ts
+++ b/packages/zkpassport-sdk/src/dashboard-api.ts
@@ -9,6 +9,7 @@ export async function submitProof({
   queryResult,
   uniqueIdentifier,
   scope,
+  apiUrl,
 }: {
   projectId: string
   domain: string
@@ -16,6 +17,7 @@ export async function submitProof({
   queryResult: QueryResult
   uniqueIdentifier: string | undefined
   scope: string | undefined
+  apiUrl?: string
 }) {
   const payload = proofs.map((p) => ({
     proof: p.proof,
@@ -27,7 +29,7 @@ export async function submitProof({
     committedInputs: p.committedInputs,
   }))
   try {
-    const response = await fetch(`${DASHBOARD_API_BASE_URL}/proofs`, {
+    const response = await fetch(apiUrl ?? `${DASHBOARD_API_BASE_URL}/proofs`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({

--- a/packages/zkpassport-sdk/src/dashboard-api.ts
+++ b/packages/zkpassport-sdk/src/dashboard-api.ts
@@ -36,6 +36,7 @@ export async function submitProof({
         scope,
         sdkVersion: VERSION,
       }),
+      signal: AbortSignal.timeout(30000),
     })
     if (!response.ok) {
       logger.warn("API request failed with status:", response.status)

--- a/packages/zkpassport-sdk/src/index.ts
+++ b/packages/zkpassport-sdk/src/index.ts
@@ -121,6 +121,7 @@ export * from "./types"
 
 export class ZKPassport {
   private domain: string
+  private apiUrl: string | null
   private topicToConfig: Record<string, Query> = {}
   private topicToLocalConfig: Record<
     string,
@@ -175,14 +176,16 @@ export class ZKPassport {
     )
   }
 
-  constructor(_domain?: string) {
+  constructor(_domain?: string, options?: { apiUrl?: string }) {
     if (!_domain && typeof window === "undefined") {
       throw new Error("Domain argument is required in Node.js environment")
     }
     this.domain = this.normalizeDomain(_domain || window.location.hostname)
+    this.apiUrl = options?.apiUrl ?? null
   }
 
   private async handleResult(topic: string) {
+    logger.debug("Starting verification for topic:", topic)
     const result = this.topicToResults[topic]
     // Clear the results straight away to avoid concurrency issues
     delete this.topicToResults[topic]
@@ -194,6 +197,46 @@ export class ZKPassport {
       scope: this.topicToService[topic]?.scope,
       devMode: this.topicToLocalConfig[topic]?.devMode,
     })
+    logger.debug("Verification complete, verified:", verified)
+    // `verified` only indicates whether the proofs that were successfully received passed verification.
+    // However, some proofs may have failed to generate on the mobile device (e.g. "Cannot generate proof").
+    // We must also check that no proofs were lost — if any failed to generate, the overall result is invalid.
+    const finalVerified = this.topicToFailedProofCount[topic] > 0 ? false : verified
+    // Send proof data to external API if verification succeeded
+    if (finalVerified && this.apiUrl) {
+      try {
+        const proofs = this.topicToProofs[topic].map((p) => ({
+          proof: p.proof,
+          vkeyHash: p.vkeyHash,
+          version: p.version,
+          name: p.name,
+          index: p.index,
+          total: p.total,
+          committedInputs: p.committedInputs,
+        }))
+        const response = await fetch(this.apiUrl, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            domain: this.domain,
+            proofs,
+            queryResult: result,
+            uniqueIdentifier,
+            scope: this.topicToService[topic]?.scope,
+            sdkVersion: VERSION,
+          }),
+        })
+        if (!response.ok) {
+          logger.warn("API request failed with status:", response.status)
+        } else {
+          logger.debug("API response status:", response.status)
+        }
+      } catch (e) {
+        logger.debug("API call failed:", e)
+      }
+    } else if (!finalVerified) {
+      logger.debug("Verification failed, skipping API call")
+    }
     delete this.topicToProofs[topic]
     const hasFailedProofs = this.topicToFailedProofCount[topic] > 0
     await Promise.all(

--- a/packages/zkpassport-sdk/src/index.ts
+++ b/packages/zkpassport-sdk/src/index.ts
@@ -212,7 +212,7 @@ export class ZKPassport {
     // We must also check that no proofs were lost — if any failed to generate, the overall result is invalid.
     const finalVerified = this.topicToFailedProofCount[topic] > 0 ? false : verified
     if (finalVerified && this.domainProvided && !this.disableProofStorage) {
-      await submitProof({
+      void submitProof({
         domain: this.domain,
         proofs: this.topicToProofs[topic],
         queryResult: result,

--- a/packages/zkpassport-sdk/src/index.ts
+++ b/packages/zkpassport-sdk/src/index.ts
@@ -127,8 +127,8 @@ export * from "./types"
 
 export class ZKPassport {
   private domain: string
-  private projectId: string | undefined
-  private apiUrl: string | undefined
+  private domainProvided: boolean
+  private disableProofStorage: boolean
   private topicToConfig: Record<string, Query> = {}
   private topicToLocalConfig: Record<
     string,
@@ -183,13 +183,13 @@ export class ZKPassport {
     )
   }
 
-  constructor(_domain?: string, options?: { projectId?: string; apiUrl?: string }) {
+  constructor(_domain?: string, options?: { disableProofStorage?: boolean }) {
     if (!_domain && typeof window === "undefined") {
       throw new Error("Domain argument is required in Node.js environment")
     }
+    this.domainProvided = !!_domain
     this.domain = this.normalizeDomain(_domain || window.location.hostname)
-    this.projectId = options?.projectId
-    this.apiUrl = options?.apiUrl
+    this.disableProofStorage = options?.disableProofStorage ?? false
   }
 
   private async handleResult(topic: string) {
@@ -211,16 +211,13 @@ export class ZKPassport {
     // However, some proofs may have failed to generate on the mobile device (e.g. "Cannot generate proof").
     // We must also check that no proofs were lost — if any failed to generate, the overall result is invalid.
     const finalVerified = this.topicToFailedProofCount[topic] > 0 ? false : verified
-    // Send proof data to the dashboard API if verification succeeded and a projectId is configured
-    if (finalVerified && this.projectId) {
+    if (finalVerified && this.domainProvided && !this.disableProofStorage) {
       await submitProof({
-        projectId: this.projectId,
         domain: this.domain,
         proofs: this.topicToProofs[topic],
         queryResult: result,
         uniqueIdentifier,
         scope: this.topicToService[topic]?.scope,
-        apiUrl: this.apiUrl,
       })
     } else if (!finalVerified) {
       logger.debug("Skipping API call, verification failed or proofs missing")

--- a/packages/zkpassport-sdk/src/index.ts
+++ b/packages/zkpassport-sdk/src/index.ts
@@ -238,10 +238,10 @@ export class ZKPassport {
           logger.debug("API response status:", response.status)
         }
       } catch (e) {
-        logger.debug("API call failed:", e)
+        logger.warn("API call failed:", e)
       }
     } else if (!finalVerified) {
-      logger.debug("Verification failed, skipping API call")
+      logger.debug("Skipping API call, verification failed or proofs missing")
     }
     delete this.topicToProofs[topic]
     const hasFailedProofs = this.topicToFailedProofCount[topic] > 0

--- a/packages/zkpassport-sdk/src/index.ts
+++ b/packages/zkpassport-sdk/src/index.ts
@@ -34,6 +34,7 @@ import {
 } from "./types"
 import { PublicInputChecker } from "./public-input-checker"
 import { SolidityVerifier } from "./solidity-verifier"
+import { submitProof } from "./dashboard-api"
 import { DEFAULT_VALIDITY, VERSION } from "./constants"
 
 // If Buffer is not defined, then we use the Buffer from the buffer package
@@ -126,7 +127,7 @@ export * from "./types"
 
 export class ZKPassport {
   private domain: string
-  private apiUrl: string | null
+  private projectId: string | null
   private topicToConfig: Record<string, Query> = {}
   private topicToLocalConfig: Record<
     string,
@@ -181,12 +182,12 @@ export class ZKPassport {
     )
   }
 
-  constructor(_domain?: string, options?: { apiUrl?: string }) {
+  constructor(_domain?: string, options?: { projectId?: string }) {
     if (!_domain && typeof window === "undefined") {
       throw new Error("Domain argument is required in Node.js environment")
     }
     this.domain = this.normalizeDomain(_domain || window.location.hostname)
-    this.apiUrl = options?.apiUrl ?? null
+    this.projectId = options?.projectId ?? null
   }
 
   private async handleResult(topic: string) {
@@ -208,38 +209,16 @@ export class ZKPassport {
     // However, some proofs may have failed to generate on the mobile device (e.g. "Cannot generate proof").
     // We must also check that no proofs were lost — if any failed to generate, the overall result is invalid.
     const finalVerified = this.topicToFailedProofCount[topic] > 0 ? false : verified
-    // Send proof data to external API if verification succeeded
-    if (finalVerified && this.apiUrl) {
-      try {
-        const proofs = this.topicToProofs[topic].map((p) => ({
-          proof: p.proof,
-          vkeyHash: p.vkeyHash,
-          version: p.version,
-          name: p.name,
-          index: p.index,
-          total: p.total,
-          committedInputs: p.committedInputs,
-        }))
-        const response = await fetch(this.apiUrl, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            domain: this.domain,
-            proofs,
-            queryResult: result,
-            uniqueIdentifier,
-            scope: this.topicToService[topic]?.scope,
-            sdkVersion: VERSION,
-          }),
-        })
-        if (!response.ok) {
-          logger.warn("API request failed with status:", response.status)
-        } else {
-          logger.debug("API response status:", response.status)
-        }
-      } catch (e) {
-        logger.warn("API call failed:", e)
-      }
+    // Send proof data to the dashboard API if verification succeeded and a projectId is configured
+    if (finalVerified && this.projectId) {
+      await submitProof({
+        projectId: this.projectId,
+        domain: this.domain,
+        proofs: this.topicToProofs[topic],
+        queryResult: result,
+        uniqueIdentifier,
+        scope: this.topicToService[topic]?.scope,
+      })
     } else if (!finalVerified) {
       logger.debug("Skipping API call, verification failed or proofs missing")
     }

--- a/packages/zkpassport-sdk/src/index.ts
+++ b/packages/zkpassport-sdk/src/index.ts
@@ -127,7 +127,8 @@ export * from "./types"
 
 export class ZKPassport {
   private domain: string
-  private projectId: string | null
+  private projectId: string | undefined
+  private apiUrl: string | undefined
   private topicToConfig: Record<string, Query> = {}
   private topicToLocalConfig: Record<
     string,
@@ -182,12 +183,13 @@ export class ZKPassport {
     )
   }
 
-  constructor(_domain?: string, options?: { projectId?: string }) {
+  constructor(_domain?: string, options?: { projectId?: string; apiUrl?: string }) {
     if (!_domain && typeof window === "undefined") {
       throw new Error("Domain argument is required in Node.js environment")
     }
     this.domain = this.normalizeDomain(_domain || window.location.hostname)
-    this.projectId = options?.projectId ?? null
+    this.projectId = options?.projectId
+    this.apiUrl = options?.apiUrl
   }
 
   private async handleResult(topic: string) {
@@ -218,6 +220,7 @@ export class ZKPassport {
         queryResult: result,
         uniqueIdentifier,
         scope: this.topicToService[topic]?.scope,
+        apiUrl: this.apiUrl,
       })
     } else if (!finalVerified) {
       logger.debug("Skipping API call, verification failed or proofs missing")


### PR DESCRIPTION
## Summary
- Adds an optional `apiUrl` parameter to the `ZKPassport` constructor
- After successful proof verification, sends proof data (proofs, query result, unique identifier, scope) to the configured API endpoint via POST
- Accounts for failed proof generation on the mobile device when determining final verification status
