### PR TITLE
fix(sdk): Public input checkers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -67,7 +67,7 @@
     },
     "packages/registry-sdk": {
       "name": "@zkpassport/registry",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "dependencies": {
         "@zkpassport/poseidon2": "^0.6.2",
         "@zkpassport/utils": "workspace:*",

--- a/packages/registry-sdk/package.json
+++ b/packages/registry-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkpassport/registry",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Registry SDK for interacting with the ZKPassport Registry",
   "author": "ZKPassport",
   "license": "Apache-2.0",

--- a/packages/zkpassport-sdk/src/public-input-checker.ts
+++ b/packages/zkpassport-sdk/src/public-input-checker.ts
@@ -110,7 +110,10 @@ export class PublicInputChecker {
           },
         }
       }
-      if (queryResult.document_type.disclose && queryResult.document_type.disclose.result !== disclosedDataIDCard.documentType) {
+      if (
+        queryResult.document_type.disclose &&
+        queryResult.document_type.disclose.result !== disclosedDataIDCard.documentType
+      ) {
         console.warn("Document type does not match the disclosed document type in query result")
         isCorrect = false
         queryResultErrors.document_type = {

--- a/packages/zkpassport-sdk/src/public-input-checker.ts
+++ b/packages/zkpassport-sdk/src/public-input-checker.ts
@@ -812,7 +812,7 @@ export class PublicInputChecker {
       if (
         queryResult.age.gt &&
         queryResult.age.gt.result &&
-        minAge !== (queryResult.age.gt.expected as number)
+        minAge !== (queryResult.age.gt.expected as number) + 1
       ) {
         console.warn("Age is not greater than the expected age")
         isCorrect = false
@@ -828,7 +828,7 @@ export class PublicInputChecker {
       if (
         queryResult.age.lt &&
         queryResult.age.lt.result &&
-        maxAge !== (queryResult.age.lt.expected as number)
+        maxAge !== (queryResult.age.lt.expected as number) - 1
       ) {
         console.warn("Age is not less than the expected age")
         isCorrect = false

--- a/packages/zkpassport-sdk/src/public-input-checker.ts
+++ b/packages/zkpassport-sdk/src/public-input-checker.ts
@@ -110,7 +110,7 @@ export class PublicInputChecker {
           },
         }
       }
-      if (queryResult.document_type.disclose?.result !== disclosedDataIDCard.documentType) {
+      if (queryResult.document_type.disclose && queryResult.document_type.disclose.result !== disclosedDataIDCard.documentType) {
         console.warn("Document type does not match the disclosed document type in query result")
         isCorrect = false
         queryResultErrors.document_type = {

--- a/packages/zkpassport-sdk/src/public-input-checker.ts
+++ b/packages/zkpassport-sdk/src/public-input-checker.ts
@@ -1106,6 +1106,22 @@ export class PublicInputChecker {
           },
         }
       }
+      if (queryResult.birthdate.gt && queryResult.birthdate.gt.result) {
+        const expectedPlusOneDay = new Date(queryResult.birthdate.gt.expected as Date)
+        expectedPlusOneDay.setDate(expectedPlusOneDay.getDate() + 1)
+        if (!areDatesEqual(minDate, expectedPlusOneDay)) {
+          console.warn("Birthdate is not greater than the expected birthdate")
+          isCorrect = false
+          queryResultErrors.birthdate = {
+            ...queryResultErrors.birthdate,
+            gt: {
+              expected: queryResult.birthdate.gt.expected,
+              received: minDate,
+              message: "Birthdate is not greater than the expected birthdate",
+            },
+          }
+        }
+      }
       if (
         queryResult.birthdate.lte &&
         queryResult.birthdate.lte.result &&
@@ -1120,6 +1136,22 @@ export class PublicInputChecker {
             received: maxDate,
             message: "Birthdate is not less than the expected birthdate",
           },
+        }
+      }
+      if (queryResult.birthdate.lt && queryResult.birthdate.lt.result) {
+        const expectedMinusOneDay = new Date(queryResult.birthdate.lt.expected as Date)
+        expectedMinusOneDay.setDate(expectedMinusOneDay.getDate() - 1)
+        if (!areDatesEqual(maxDate, expectedMinusOneDay)) {
+          console.warn("Birthdate is not less than the expected birthdate")
+          isCorrect = false
+          queryResultErrors.birthdate = {
+            ...queryResultErrors.birthdate,
+            lt: {
+              expected: queryResult.birthdate.lt.expected,
+              received: maxDate,
+              message: "Birthdate is not less than the expected birthdate",
+            },
+          }
         }
       }
       if (queryResult.birthdate.range) {
@@ -2274,11 +2306,13 @@ export class PublicInputChecker {
                 ProofType.BIRTHDATE,
                 birthdateCommittedInputs.minDateTimestamp,
                 birthdateCommittedInputs.maxDateTimestamp,
+                0,
               )
             : await getDateParameterCommitment(
                 ProofType.BIRTHDATE,
                 birthdateCommittedInputs.minDateTimestamp,
                 birthdateCommittedInputs.maxDateTimestamp,
+                0,
               )
           if (!paramCommitments.includes(birthdateParameterCommitment)) {
             console.warn("This proof does not verify the birthdate")

--- a/packages/zkpassport-sdk/tests/public-input-checker.test.ts
+++ b/packages/zkpassport-sdk/tests/public-input-checker.test.ts
@@ -1177,6 +1177,64 @@ describe("PublicInputChecker - committed inputs vs queryResult", () => {
       expect(queryResultErrors.birthdate?.lte).toBeDefined()
     })
 
+    test("passes when committed minDate matches queryResult gt (offset by +1 day)", () => {
+      const proof = makeBirthdateProof(new Date("1995-01-02"), null)
+      const originalQuery: Query = { birthdate: { gt: new Date("1995-01-01") } }
+      const queryResult: QueryResult = {
+        birthdate: { gt: { expected: new Date("1995-01-01"), result: true } },
+      }
+      const { isCorrect } = PublicInputChecker.checkBirthdatePublicInputs(
+        proof,
+        originalQuery,
+        queryResult,
+      )
+      expect(isCorrect).toBe(true)
+    })
+
+    test("fails when committed minDate does not match queryResult gt expected +1 day", () => {
+      const proof = makeBirthdateProof(new Date("1995-01-01"), null)
+      const originalQuery: Query = { birthdate: { gt: new Date("1995-01-01") } }
+      const queryResult: QueryResult = {
+        birthdate: { gt: { expected: new Date("1995-01-01"), result: true } },
+      }
+      const { isCorrect, queryResultErrors } = PublicInputChecker.checkBirthdatePublicInputs(
+        proof,
+        originalQuery,
+        queryResult,
+      )
+      expect(isCorrect).toBe(false)
+      expect(queryResultErrors.birthdate?.gt).toBeDefined()
+    })
+
+    test("passes when committed maxDate matches queryResult lt (offset by -1 day)", () => {
+      const proof = makeBirthdateProof(null, new Date("1997-12-30"))
+      const originalQuery: Query = { birthdate: { lt: new Date("1997-12-31") } }
+      const queryResult: QueryResult = {
+        birthdate: { lt: { expected: new Date("1997-12-31"), result: true } },
+      }
+      const { isCorrect } = PublicInputChecker.checkBirthdatePublicInputs(
+        proof,
+        originalQuery,
+        queryResult,
+      )
+      expect(isCorrect).toBe(true)
+    })
+
+    test("fails when committed maxDate does not match queryResult lt expected -1 day", () => {
+      const proof = makeBirthdateProof(null, new Date("1997-12-31"))
+      const originalQuery: Query = { birthdate: { lt: new Date("1997-12-31") } }
+      const queryResult: QueryResult = {
+        birthdate: { lt: { expected: new Date("1997-12-31"), result: true } },
+      }
+      const { isCorrect, queryResultErrors } = PublicInputChecker.checkBirthdatePublicInputs(
+        proof,
+        originalQuery,
+        queryResult,
+      )
+      expect(isCorrect).toBe(false)
+      expect(queryResultErrors.birthdate?.lt).toBeDefined()
+    })
+
     test("fails when birthdate is not set in queryResult", () => {
       const proof = makeBirthdateProof(new Date("2000-01-01"), null)
       const originalQuery: Query = { birthdate: { gte: new Date("2000-01-01") } }

--- a/packages/zkpassport-sdk/tests/public-input-checker.test.ts
+++ b/packages/zkpassport-sdk/tests/public-input-checker.test.ts
@@ -869,7 +869,7 @@ describe("PublicInputChecker - committed inputs vs queryResult", () => {
     })
 
     test("passes when committed maxAge matches queryResult lt", () => {
-      const proof = makeAgeProof(0, 65)
+      const proof = makeAgeProof(0, 64)
       const originalQuery: Query = { age: { lt: 65 } }
       const queryResult: QueryResult = {
         age: { lt: { expected: 65, result: true } },
@@ -989,7 +989,7 @@ describe("PublicInputChecker - committed inputs vs queryResult", () => {
     })
 
     test("passes when committed minAge matches queryResult gt", () => {
-      const proof = makeAgeProof(17, 0)
+      const proof = makeAgeProof(18, 0)
       const originalQuery: Query = { age: { gt: 17 } }
       const queryResult: QueryResult = {
         age: { gt: { expected: 17, result: true } },


### PR DESCRIPTION
The following fixes were implemented:

- **document_type disclose check** — `.eq("document_type", "passport")` without `.disclose()` failed verification because the disclose check compared `undefined` against the actual value. Added the same guard every other field already has.

- **age strict comparison offset** — gt/lt age queries are converted to gte/lte by the mobile app (e.g. `lt(50)` → maxAge=49), but the SDK compared committed inputs against the original query value. Now accounts for the ±1 offset.

- **birthdate in compressed-evm mode** — The outer proof handler double-applied `SECONDS_BETWEEN_1900_AND_1970` when computing the birthdate parameter commitment. Also adds the missing gt/lt committed input checks for birthdate, matching the age pattern.

