### PR TITLE
feat(workspace): React wrapper for @zkpassport/ui (PR 3/5)

### DIFF
--- a/packages/zkpassport-ui/src/index.ts
+++ b/packages/zkpassport-ui/src/index.ts
@@ -4,7 +4,11 @@
 // prepend for the published file.
 
 export { QRCard, type QRCardProps } from "./react/QRCard"
-export { useZKPassportRequest, type UseZKPassportRequestOptions } from "./react/use-request"
+export {
+  useZKPassportRequest,
+  type UseZKPassportRequestOptions,
+  type ZKPassportLike,
+} from "./react/use-request"
 
 // Also re-export the vanilla mount + all types so React consumers can drop
 // down to the imperative API when they need to.

--- a/packages/zkpassport-ui/src/react/QRCard.tsx
+++ b/packages/zkpassport-ui/src/react/QRCard.tsx
@@ -1,14 +1,24 @@
-import type { ReactElement } from "react"
+import { useEffect, useRef, type ReactElement } from "react"
 
-import type { QRCardOptions } from "../core/types"
+import type { QRCardHandle, QRCardOptions } from "../core/types"
+import { mount } from "../vanilla/mount"
 
 export type QRCardProps = QRCardOptions
 
 /**
  * React wrapper around the vanilla `mount()` function.
  *
- * Use this in any React app (Next.js, Vite, CRA). For Next.js App Router,
- * the package already includes the `"use client"` directive — no extra setup.
+ * Renders a host `<div>`, mounts the imperative card into it on first effect,
+ * and pushes prop changes through `handle.update()` on subsequent renders.
+ *
+ * Consumers do NOT need to memoize callback props with `useCallback` — the
+ * underlying state machine reads handlers via a getter at fire time
+ * ([core/state.ts](../core/state.ts)), and the vanilla `update()` shallow-diff
+ * ignores callback fields, so a parent re-render that recreates handlers does
+ * no work here.
+ *
+ * The `"use client"` directive is prepended to the React entry bundle
+ * post-build by tsup; no per-file directive is needed.
  *
  * @example
  * <QRCard
@@ -19,10 +29,30 @@ export type QRCardProps = QRCardOptions
  *   onSuccess={(r) => console.log(r)}
  * />
  */
-export function QRCard(props: QRCardProps): ReactElement | null {
-  // PR 1 stub. Real implementation lands in PR 3.
-  // The component will use `useRef` + `useEffect` to call `mount()` from the vanilla entry,
-  // diff `options` shallowly on each render, and call `handle.update()` for changed fields.
-  void props
-  throw new Error("@zkpassport/ui: <QRCard /> not implemented in PR 1 scaffolding")
+export function QRCard(props: QRCardProps): ReactElement {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const handleRef = useRef<QRCardHandle | null>(null)
+  // Captures the props used for the very first `mount()` call so the
+  // mount-only effect below stays free of changing dependencies.
+  const initialPropsRef = useRef(props)
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+    const handle = mount(container, initialPropsRef.current)
+    handleRef.current = handle
+    return () => {
+      handle.unmount()
+      handleRef.current = null
+    }
+  }, [])
+
+  // Push every prop change through to the imperative handle. The vanilla
+  // `update()` shallow-diffs and no-ops when nothing actually changed, so
+  // running this on every render is cheap.
+  useEffect(() => {
+    handleRef.current?.update(props)
+  })
+
+  return <div ref={containerRef} />
 }

--- a/packages/zkpassport-ui/src/react/use-request.ts
+++ b/packages/zkpassport-ui/src/react/use-request.ts
@@ -6,6 +6,8 @@
 // The vanilla / core surface stays duck-typed (see ZKPassportRequestLike in
 // core/types.ts) so non-React consumers don't need the SDK installed at all.
 
+import { useEffect, useRef, useState } from "react"
+
 import type { QueryBuilder, QueryBuilderResult, ZKPassport } from "@zkpassport/sdk"
 
 export type UseZKPassportRequestOptions = {
@@ -23,13 +25,56 @@ export type UseZKPassportRequestOptions = {
  * Returns `null` while preparing; returns the built request once resolved.
  * On `deps` change or unmount, the previous in-flight build is discarded
  * (no setState after unmount; no race between two builds resolving out of order).
+ *
+ * `sdk`, `service`, and `query` are read live via refs, so they always reflect
+ * the latest values without triggering a rebuild on their own. Pass `deps`
+ * explicitly to control when a rebuild happens.
  */
 export function useZKPassportRequest(
   sdk: ZKPassport,
   options: UseZKPassportRequestOptions,
 ): QueryBuilderResult | null {
-  // PR 1 stub. Real implementation lands in PR 3.
-  void sdk
-  void options
-  throw new Error("@zkpassport/ui: useZKPassportRequest() not implemented in PR 1 scaffolding")
+  const { service, query, deps = [] } = options
+
+  const [request, setRequest] = useState<QueryBuilderResult | null>(null)
+
+  const sdkRef = useRef(sdk)
+  const serviceRef = useRef(service)
+  const queryRef = useRef(query)
+  sdkRef.current = sdk
+  serviceRef.current = service
+  queryRef.current = query
+
+  useEffect(() => {
+    let cancelled = false
+    // Flash back to `null` so consumers (e.g. <QRCard>) see the rebuild
+    // as a transition to `preparing`, rather than briefly displaying a QR
+    // pointing at a torn-down bridge.
+    setRequest(null)
+
+    void (async () => {
+      try {
+        const builder = await sdkRef.current.request(serviceRef.current)
+        if (cancelled) return
+        const built = queryRef.current(builder).done()
+        if (cancelled) return
+        setRequest(built)
+      } catch (cause) {
+        if (cancelled) return
+        // The hook's public surface is `QueryBuilderResult | null`. Surface
+        // the failure via the console so it's debuggable; downstream errors
+        // (e.g. bridge failures after the request is live) flow through
+        // <QRCard>'s `onError` callback.
+        console.error("[@zkpassport/ui] useZKPassportRequest: failed to build request", cause)
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+    // `deps` is the canonical rebuild signal; sdk/service/query are read via
+    // refs above so they don't need to be in the dependency array.
+  }, deps)
+
+  return request
 }

--- a/packages/zkpassport-ui/src/react/use-request.ts
+++ b/packages/zkpassport-ui/src/react/use-request.ts
@@ -3,12 +3,27 @@
 // package.json), and these are `import type` statements only — erased at
 // build time, so no runtime coupling and no impact on bundle size.
 //
+// The `sdk` parameter is typed as `ZKPassportLike` (a structural subset of
+// the `ZKPassport` class) rather than the concrete class. TypeScript treats
+// classes with private members nominally, so when the UI package's types are
+// built against one `@zkpassport/sdk` version and a consumer's app uses a
+// different one (or a locally-linked workspace copy), passing a `ZKPassport`
+// instance fails with "missing private fields" even though the runtime is
+// fine. Picking only the method we actually need drops the nominal identity.
+//
 // The vanilla / core surface stays duck-typed (see ZKPassportRequestLike in
 // core/types.ts) so non-React consumers don't need the SDK installed at all.
 
 import { useEffect, useRef, useState } from "react"
 
 import type { QueryBuilder, QueryBuilderResult, ZKPassport } from "@zkpassport/sdk"
+
+/**
+ * Structural subset of `ZKPassport` that `useZKPassportRequest` actually
+ * uses. Any object exposing a compatible `request(service): Promise<QueryBuilder>`
+ * method satisfies this — useful for tests/mocks too.
+ */
+export type ZKPassportLike = Pick<ZKPassport, "request">
 
 export type UseZKPassportRequestOptions = {
   /** Passed straight to `sdk.request({...})`. */
@@ -26,12 +41,19 @@ export type UseZKPassportRequestOptions = {
  * On `deps` change or unmount, the previous in-flight build is discarded
  * (no setState after unmount; no race between two builds resolving out of order).
  *
- * `sdk`, `service`, and `query` are read live via refs, so they always reflect
- * the latest values without triggering a rebuild on their own. Pass `deps`
- * explicitly to control when a rebuild happens.
+ * Pass `sdk = null` while the SDK is still being instantiated (e.g. in SSR
+ * setups where `new ZKPassport()` has to wait for `useEffect` because the
+ * SDK constructor reads `window.location.hostname`). The hook returns `null`
+ * until a real SDK arrives, and `<QRCard>` will sit in its `preparing` state.
+ *
+ * `sdk`, `service`, and `query` are read live via refs, so swapping between
+ * two real SDK instances doesn't trigger a rebuild on its own. Pass `deps`
+ * explicitly to control when a rebuild happens. The `null` → instance
+ * transition is treated as a rebuild trigger so the first request actually
+ * gets built once the SDK becomes available.
  */
 export function useZKPassportRequest(
-  sdk: ZKPassport,
+  sdk: ZKPassportLike | null,
   options: UseZKPassportRequestOptions,
 ): QueryBuilderResult | null {
   const { service, query, deps = [] } = options
@@ -45,6 +67,11 @@ export function useZKPassportRequest(
   serviceRef.current = service
   queryRef.current = query
 
+  // We want a null → instance transition to trigger a rebuild, but identity
+  // swaps between two real SDKs to keep going through the ref. Tracking just
+  // the presence of an SDK in the effect deps gives us both.
+  const hasSdk = sdk !== null
+
   useEffect(() => {
     let cancelled = false
     // Flash back to `null` so consumers (e.g. <QRCard>) see the rebuild
@@ -52,9 +79,16 @@ export function useZKPassportRequest(
     // pointing at a torn-down bridge.
     setRequest(null)
 
+    const currentSdk = sdkRef.current
+    if (!currentSdk) {
+      return () => {
+        cancelled = true
+      }
+    }
+
     void (async () => {
       try {
-        const builder = await sdkRef.current.request(serviceRef.current)
+        const builder = await currentSdk.request(serviceRef.current)
         if (cancelled) return
         const built = queryRef.current(builder).done()
         if (cancelled) return
@@ -73,8 +107,9 @@ export function useZKPassportRequest(
       cancelled = true
     }
     // `deps` is the canonical rebuild signal; sdk/service/query are read via
-    // refs above so they don't need to be in the dependency array.
-  }, deps)
+    // refs above. `hasSdk` is included so the null → instance transition
+    // (common with SSR-deferred SDK init) triggers exactly one rebuild.
+  }, [hasSdk, ...deps])
 
   return request
 }

--- a/packages/zkpassport-ui/tsup.config.ts
+++ b/packages/zkpassport-ui/tsup.config.ts
@@ -64,6 +64,10 @@ const umdConfig: Options = {
   minify: !isDev,
   noExternal: [/.*/],
   loader: { ".css": "text" },
+  // Without this, esbuild ignores the `browser` field in qrcode's package.json
+  // and bundles its Node entry — which calls `require("fs")` for terminal QR
+  // rendering and crashes the IIFE at load time in any browser.
+  platform: "browser",
 }
 
 // 3) Standalone CSS at dist/styles.css for CSP-strict consumers.


### PR DESCRIPTION
## Summary

Third PR in the @zkpassport/ui series. Replaces the PR 1 React stubs with real implementations on top of the vanilla core that landed in PR 2.

- **`QRCard.tsx`** — renders a host `<div>`, calls `mount()` once in an empty-deps effect, and pushes every prop change through `handle.update(props)` in a follow-up effect. The vanilla `update()` shallow-diffs and ignores callback fields ([core/state.ts](packages/zkpassport-ui/src/core/state.ts) reads handlers via a getter at fire time), so consumers don't need `useCallback` to stabilize `onSuccess` / `onError` / etc. React 18 StrictMode double-mount is handled by the existing generation-token machinery in `state.ts` plus the effect's cleanup.
- **`use-request.ts`** — `useZKPassportRequest(sdk, { service, query, deps })` owns the `await sdk.request(...).done()` boilerplate. `sdk` / `service` / `query` are read through refs so they always reflect the latest values without retriggering. Rebuilds only fire when the user-provided `deps` change, and stale in-flight builds are discarded via a `cancelled` closure flag (no `setState` after unmount, no out-of-order resolution between two concurrent builds). On `deps` change the hook nulls the current value first, so `<QRCard>` transitions back through `preparing` instead of briefly showing a QR pointing at a torn-down bridge.

`"use client"` stays only in `src/index.ts`; tsup's `onSuccess` prepends it to the React entry bundles post-build (the React source files themselves are directive-free, since the bundle-level prepend is what actually ships).

## Stacking

This branches off `rb/qr-react-component` (the integration branch for the 5-PR series), **not** `main`. PR target is set accordingly. Title scope is `workspace` because `check-pr.yml` runs from `main` via `pull_request_target` and `main` doesn't have `ui` in its allowed scopes until the full series merges.

## Test plan

- [x] `bun run check` — tsc + prettier + eslint, all clean
- [x] `bun run build` — ESM / CJS / IIFE / DTS all produced; `"use client"` confirmed at the top of `dist/{esm,cjs}/index.{js,cjs}` and absent from `dist/{esm,cjs}/vanilla.{js,cjs}` and the IIFE bundle
- [x] `bun run validate-package` — publint + attw both green; both subpath exports (`@zkpassport/ui` and `@zkpassport/ui/vanilla`) resolve under node16 (CJS + ESM) and bundler conditions
- [ ] Manual smoke in a fresh Next.js App Router app (PR 5 territory; the integration examples land alongside the IIFE in PR 4)
- [ ] Manual smoke in a fresh Vite + React app (same — deferred to PR 5)
- [ ] React 18 StrictMode double-mount verified visually (deferred to PR 4/5 alongside the examples; covered structurally by `state.ts`'s generation tokens and the effect cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)