### PR TITLE
feat(workspace): Drop IIFE bundle from @zkpassport/ui (PR 4/5)

### DIFF
--- a/packages/zkpassport-ui/package.json
+++ b/packages/zkpassport-ui/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0-beta.0",
   "// private": "Stays true while the package is stubbed. Flip to false (or remove) once PR 2/3 land real implementations and we're ready to publish 0.1.0-beta.0.",
   "private": true,
-  "description": "Drop-in QR verification card for ZKPassport. Works in React, vanilla JS, and via <script> tag.",
+  "description": "Drop-in QR verification card for ZKPassport. Works in React and any bundler-based stack (Vue/Svelte/Solid/Astro/vanilla JS) via the /vanilla entry.",
   "author": "ZKPassport",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/zkpassport-ui/tsup.config.ts
+++ b/packages/zkpassport-ui/tsup.config.ts
@@ -49,28 +49,7 @@ const npmConfigs: Options[] = (["esm", "cjs"] as const).map((format) => ({
   },
 }))
 
-// 2) IIFE bundle for <script> tag — bundles everything (qrcode + CSS string baked in).
-const umdConfig: Options = {
-  entry: { "zkpassport-ui": "src/vanilla.ts" },
-  format: "iife",
-  globalName: "ZKPassportUI",
-  outDir: "dist/umd",
-  // Override tsup's default `.global.js` suffix; we want a clean `zkpassport-ui.js`.
-  outExtension: () => ({ js: ".js" }),
-  // Don't clean dist (npmConfigs already did); just our subfolder.
-  clean: false,
-  splitting: false,
-  sourcemap: true,
-  minify: !isDev,
-  noExternal: [/.*/],
-  loader: { ".css": "text" },
-  // Without this, esbuild ignores the `browser` field in qrcode's package.json
-  // and bundles its Node entry — which calls `require("fs")` for terminal QR
-  // rendering and crashes the IIFE at load time in any browser.
-  platform: "browser",
-}
-
-// 3) Standalone CSS at dist/styles.css for CSP-strict consumers.
+// 2) Standalone CSS at dist/styles.css for CSP-strict consumers.
 const cssConfig: Options = {
   entry: { styles: "src/core/styles.css" },
   outDir: "dist",
@@ -78,4 +57,10 @@ const cssConfig: Options = {
   loader: { ".css": "copy" },
 }
 
-export default defineConfig([...npmConfigs, umdConfig, cssConfig])
+// Note: no IIFE/UMD output for v0.1.0-beta.0. A complete `<script>`-tag
+// integration is blocked by browsers refusing to construct the bb.js Web
+// Worker cross-origin from esm.sh (the only ESM→browser bridge available
+// for @zkpassport/sdk today). See the design doc's "No IIFE in v0.1"
+// section for context. Adding the IIFE back is non-breaking when the SDK
+// story unlocks it (UMD bundle / verify-on-server / dedicated CDN dist).
+export default defineConfig([...npmConfigs, cssConfig])


### PR DESCRIPTION
## Summary

Drops the IIFE/UMD output from `@zkpassport/ui` for v0.1.0-beta.0. The build now produces ESM + CJS + standalone CSS only — no `dist/umd/`. Replaces the original plan for PR 4 (IIFE bundle + static `<script>`-tag example) after discovering the integration doesn't actually work end-to-end.

## Why

While building the static example in #195 (now closed), the full no-bundler flow worked through QR generation and phone-side scan, but `verify()` failed deterministically with:

\`\`\`
SecurityError: Failed to construct 'Worker': Script at
'https://esm.sh/@aztec/bb.js@4.2.0-aztecnr-rc.2/es2022/main.worker.js'
cannot be accessed from origin 'http://localhost:5173'.
\`\`\`

`@zkpassport/sdk` runs `verify()` in the browser to validate the returned proof. `verify()` spawns a Web Worker from `@aztec/bb.js`. With the SDK loaded via esm.sh (the only path that makes an ESM-only npm package usable from a `<script>` tag today), the Worker URL is cross-origin from the page. **Browsers enforce same-origin policy on Worker constructors as a hard security boundary — CORS does not relax it.** No HTML-level config can route around this; only a bundler that emits the worker file to the same origin as the page works.

Shipping the IIFE without a functional integration would imply a path that doesn't work end-to-end. Customers would find `dist/umd/zkpassport-ui.js`, try the design doc's "Plain HTML — `<script>` tag" example, hit the same Worker wall, and conclude the script-tag integration is broken.

The IIFE is **non-breaking to re-add later** when one of these unlocks:
- `@zkpassport/sdk` ships its own UMD/IIFE that colocates bb.js's worker
- The SDK exposes a verify-on-server path so browsers don't need bb.js workers
- A dedicated `@zkpassport/cdn` bundle ships SDK + UI + bb.js together

`src/vanilla.ts` stays as the entry point for non-React bundler consumers (Vue/Svelte/Solid/Astro via `@zkpassport/ui/vanilla`); when we re-enable the IIFE, it'll be the IIFE entry too.

## Changes

- `packages/zkpassport-ui/tsup.config.ts` — remove `umdConfig`, remove `import { promises as fs }`/`import path` headers that are still needed for `prependUseClient` (kept), simplify the `defineConfig` call to `[...npmConfigs, cssConfig]`
- `packages/zkpassport-ui/package.json` — package description no longer claims script-tag support

## Test plan
- [x] `bun run build` → `dist/` contains only `cjs/`, `esm/`, `styles.css` (no `umd/`)
- [x] `bun run validate-package` → all entry points pass attw (`@zkpassport/ui` and `@zkpassport/ui/vanilla` both 🟢 for CJS, ESM, bundler resolutions)
- [x] `dist/esm/index.js`, `dist/cjs/index.cjs`, `dist/esm/vanilla.js`, `dist/cjs/vanilla.cjs` all generated as before
- [ ] React wrapper still consumable from a Next.js / Vite + React app (no change to those output paths, but worth a sanity check)

Stacked on top of #194. Squash-merge to match prior PRs in this stack (#192, #193, #194). PR 5/5 will publish `0.1.0-beta.0` to npm — smaller surface area than originally planned.

Closes #195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)