### PR TITLE
feat(workspace): Simplify @zkpassport/ui QRCard integration API

### DIFF
--- a/packages/zkpassport-ui/src/core/service-bridge.ts
+++ b/packages/zkpassport-ui/src/core/service-bridge.ts
@@ -1,0 +1,29 @@
+// Hidden contract between `useZKPassportRequest` (React) and the `mount()`
+// renderer: the hook attaches the service (`name` / `logo`) under this symbol
+// to the built request so the card can render its header without the consumer
+// having to pass `appName` / `appIcon` as props on `<QRCard>`. Same pattern as
+// `retry-bridge.ts` — see comment there for the `Symbol.for` rationale.
+
+export const ZKP_SERVICE = Symbol.for("@zkpassport/ui/service")
+
+// Only the fields the card actually renders today. If a future state ever
+// needs more (e.g. surface `purpose` under the title), extend this type AND
+// the writer in `react/use-request.ts` AND the reader in `vanilla/mount.ts`
+// in the same change — silent drift between the three is the whole risk of
+// a hidden-symbol contract.
+export type AttachedService = {
+  name: string
+  logo: string
+}
+
+/** Read the attached service, if any. */
+export function readService(target: unknown): AttachedService | undefined {
+  if (target === null || (typeof target !== "object" && typeof target !== "function")) {
+    return undefined
+  }
+  const value = (target as Record<symbol, unknown>)[ZKP_SERVICE]
+  if (value === null || typeof value !== "object") return undefined
+  const { name, logo } = value as Partial<AttachedService>
+  if (typeof name !== "string" || typeof logo !== "string") return undefined
+  return { name, logo }
+}

--- a/packages/zkpassport-ui/src/core/service-bridge.ts
+++ b/packages/zkpassport-ui/src/core/service-bridge.ts
@@ -1,22 +1,18 @@
-// Hidden contract between `useZKPassportRequest` (React) and the `mount()`
-// renderer: the hook attaches the service (`name` / `logo`) under this symbol
-// to the built request so the card can render its header without the consumer
-// having to pass `appName` / `appIcon` as props on `<QRCard>`. Same pattern as
-// `retry-bridge.ts` — see comment there for the `Symbol.for` rationale.
+// Hidden contract between `useZKPassportRequest` and `mount()`: the hook
+// attaches the service under this symbol on the built request so the card can
+// render its header without the consumer passing `appName` / `appIcon` props.
+// Same pattern as `retry-bridge.ts`.
 
 export const ZKP_SERVICE = Symbol.for("@zkpassport/ui/service")
 
-// Only the fields the card actually renders today. If a future state ever
-// needs more (e.g. surface `purpose` under the title), extend this type AND
-// the writer in `react/use-request.ts` AND the reader in `vanilla/mount.ts`
-// in the same change — silent drift between the three is the whole risk of
-// a hidden-symbol contract.
+// Only the fields the card renders today. If you extend this, also update the
+// writer in `react/use-request.ts` and the reader in `vanilla/mount.ts` in the
+// same change — silent drift between the three is the risk of a hidden contract.
 export type AttachedService = {
   name: string
   logo: string
 }
 
-/** Read the attached service, if any. */
 export function readService(target: unknown): AttachedService | undefined {
   if (target === null || (typeof target !== "object" && typeof target !== "function")) {
     return undefined

--- a/packages/zkpassport-ui/src/core/types.ts
+++ b/packages/zkpassport-ui/src/core/types.ts
@@ -1,10 +1,7 @@
 /**
- * Structural type of the object returned by `sdk.request(...).<gates>.done()`.
- *
- * We deliberately do NOT import this from `@zkpassport/sdk` so the UI package
- * has no runtime dependency on the SDK — versions can evolve independently and
- * the IIFE bundle stays slim. The shape is duck-typed; any object matching it
- * works.
+ * Structural shape of `sdk.request(...).<gates>.done()`. Duck-typed on purpose
+ * so the UI package has no runtime dependency on `@zkpassport/sdk` and the two
+ * can evolve independently.
  */
 export type ZKPassportRequestLike = {
   url: string
@@ -23,9 +20,8 @@ export type ZKPassportRequestLike = {
 export type QRCardError = {
   /** Stable identifier for branching. See the error code taxonomy in the design doc. */
   code: "user_rejected" | "proof_failed" | "bridge_error" | "unknown"
-  /** Human-readable message — suitable for logs; not necessarily for end users. */
+  /** Suitable for logs; not necessarily user-facing. */
   message: string
-  /** Underlying error from the SDK, if any. */
   cause?: unknown
 }
 
@@ -40,35 +36,25 @@ export type QRCardOptions = {
   request: ZKPassportRequestLike | null
 
   /**
-   * App display strings for the header. Optional for React consumers using
-   * `useZKPassportRequest` — the hook attaches the service it built the
-   * request from to the request object (hidden symbol; see
-   * `core/service-bridge.ts`), and the card reads from there as a fallback.
-   * Vanilla consumers that build the request themselves should pass these.
-   * When provided, props win over the attached service.
+   * Header strings. Optional for React consumers using `useZKPassportRequest`
+   * — the hook attaches them to the built request (see
+   * `core/service-bridge.ts`) and the card reads them as a fallback. Props
+   * win over the attached service. Vanilla consumers should pass these.
    */
   appName?: string
   appIcon?: string
 
-  /**
-   * Reserved for forward compatibility. Accepted by the type but ignored
-   * by the renderer in v1 — the card is light-only. Dark mode will be
-   * re-enabled in a future minor without a breaking change. See the
-   * comment at the top of `src/core/styles.css` for the re-attachment plan.
-   */
+  /** Reserved — ignored in v1 (light-only). See top of `core/styles.css`. */
   theme?: "light" | "dark" | "auto"
 
-  /** Fires once when the card first becomes scannable (bridge connected, QR visible). */
+  /** Fires once when the QR first becomes scannable. */
   onReady?: () => void
   onSuccess?: (response: QRCardSuccessResponse) => void
   onReject?: () => void
   onError?: (err: QRCardError) => void
   /**
-   * Fires when the user clicks the retry button in the error state.
-   *
-   * React consumers using `useZKPassportRequest` get auto-retry for free —
-   * the hook rebuilds the request and a new QR appears with no extra wiring.
-   * Other consumers should rebuild the request and call
+   * Fires when the user clicks retry. Hook consumers get auto-retry for free;
+   * vanilla consumers should rebuild the request and call
    * `handle.update({ request })` themselves.
    */
   onRetryClicked?: () => void
@@ -79,7 +65,7 @@ export type QRCardHandle = {
   unmount(): void
 }
 
-/** Internal UI state — exported for testing, not part of the public API surface. */
+/** Internal — exported for testing, not part of the public API. */
 export type QRCardState =
   | "preparing"
   | "connecting"

--- a/packages/zkpassport-ui/src/core/types.ts
+++ b/packages/zkpassport-ui/src/core/types.ts
@@ -39,10 +39,16 @@ export type QRCardOptions = {
   /** Result of `sdk.request({...}).<gates>.done()`. May be `null` while preparing. */
   request: ZKPassportRequestLike | null
 
-  /** Required — drives the card header from the first paint. */
-  appName: string
-  appIcon: string
-  purpose: string
+  /**
+   * App display strings for the header. Optional for React consumers using
+   * `useZKPassportRequest` — the hook attaches the service it built the
+   * request from to the request object (hidden symbol; see
+   * `core/service-bridge.ts`), and the card reads from there as a fallback.
+   * Vanilla consumers that build the request themselves should pass these.
+   * When provided, props win over the attached service.
+   */
+  appName?: string
+  appIcon?: string
 
   /**
    * Reserved for forward compatibility. Accepted by the type but ignored

--- a/packages/zkpassport-ui/src/react/QRCard.tsx
+++ b/packages/zkpassport-ui/src/react/QRCard.tsx
@@ -6,39 +6,19 @@ import { mount } from "../vanilla/mount"
 export type QRCardProps = QRCardOptions
 
 /**
- * React wrapper around the vanilla `mount()` function.
+ * React wrapper around the vanilla `mount()`.
  *
- * Renders a host `<div>`, mounts the imperative card into it on first effect,
- * and pushes prop changes through `handle.update()` on subsequent renders.
- *
- * Consumers do NOT need to memoize callback props with `useCallback` — the
- * underlying state machine reads handlers via a getter at fire time
- * ([core/state.ts](../core/state.ts)), and the vanilla `update()` shallow-diff
- * ignores callback fields, so a parent re-render that recreates handlers does
- * no work here.
- *
- * The `"use client"` directive is prepended to the React entry bundle
- * post-build by tsup; no per-file directive is needed.
+ * Callbacks do NOT need `useCallback` — the state machine reads handlers live
+ * at fire time and the vanilla `update()` shallow-diff ignores callback fields.
  *
  * @example
- * // Minimal — `appName` / `appIcon` come from the service the hook built with:
  * const request = useZKPassportRequest(sdk, { service, query })
  * <QRCard request={request} onSuccess={(r) => console.log(r)} />
- *
- * @example
- * // Or pass them explicitly (vanilla builders, or to override the hook's values):
- * <QRCard
- *   request={request}
- *   appName="Your App"
- *   appIcon="/logo.png"
- *   onSuccess={(r) => console.log(r)}
- * />
  */
 export function QRCard(props: QRCardProps): ReactElement {
   const containerRef = useRef<HTMLDivElement>(null)
   const handleRef = useRef<QRCardHandle | null>(null)
-  // Captures the props used for the very first `mount()` call so the
-  // mount-only effect below stays free of changing dependencies.
+  // Keeps the mount-only effect free of changing dependencies.
   const initialPropsRef = useRef(props)
 
   useEffect(() => {
@@ -52,9 +32,8 @@ export function QRCard(props: QRCardProps): ReactElement {
     }
   }, [])
 
-  // Push every prop change through to the imperative handle. The vanilla
-  // `update()` shallow-diffs and no-ops when nothing actually changed, so
-  // running this on every render is cheap.
+  // Vanilla `update()` shallow-diffs and no-ops when nothing changed, so
+  // running this every render is cheap.
   useEffect(() => {
     handleRef.current?.update(props)
   })

--- a/packages/zkpassport-ui/src/react/QRCard.tsx
+++ b/packages/zkpassport-ui/src/react/QRCard.tsx
@@ -21,11 +21,16 @@ export type QRCardProps = QRCardOptions
  * post-build by tsup; no per-file directive is needed.
  *
  * @example
+ * // Minimal — `appName` / `appIcon` come from the service the hook built with:
+ * const request = useZKPassportRequest(sdk, { service, query })
+ * <QRCard request={request} onSuccess={(r) => console.log(r)} />
+ *
+ * @example
+ * // Or pass them explicitly (vanilla builders, or to override the hook's values):
  * <QRCard
  *   request={request}
  *   appName="Your App"
  *   appIcon="/logo.png"
- *   purpose="Verify you're over 18"
  *   onSuccess={(r) => console.log(r)}
  * />
  */

--- a/packages/zkpassport-ui/src/react/use-request.ts
+++ b/packages/zkpassport-ui/src/react/use-request.ts
@@ -17,6 +17,7 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 
 import { ZKP_RETRY } from "../core/retry-bridge"
+import { ZKP_SERVICE } from "../core/service-bridge"
 import type { QueryBuilder, QueryBuilderResult, ZKPassport } from "@zkpassport/sdk"
 
 /**
@@ -29,7 +30,7 @@ export type ZKPassportLike = Pick<ZKPassport, "request">
 export type UseZKPassportRequestOptions = {
   /** Passed straight to `sdk.request({...})`. */
   service: { name: string; logo: string; purpose: string; scope?: string }
-  /** Apply gates to the builder. Return the chained builder. */
+  /** Apply gates and return the chained builder — its `.done()` is called for you. */
   query: (builder: QueryBuilder) => QueryBuilder
   /** Re-runs the request build when any value changes. Default: `[]` (build once on mount). */
   deps?: unknown[]
@@ -105,6 +106,15 @@ export function useZKPassportRequest(
         // any SDK field. The renderer reads it back via `readRetry()`.
         Object.defineProperty(built, ZKP_RETRY, {
           value: retry,
+          enumerable: false,
+          configurable: true,
+        })
+        // Same trick for the service strings — lets <QRCard> render its header
+        // from the data we already have, so React consumers don't have to pass
+        // `appName` / `appIcon` props in addition to declaring `service` here.
+        const svc = serviceRef.current
+        Object.defineProperty(built, ZKP_SERVICE, {
+          value: { name: svc.name, logo: svc.logo },
           enumerable: false,
           configurable: true,
         })

--- a/packages/zkpassport-ui/src/react/use-request.ts
+++ b/packages/zkpassport-ui/src/react/use-request.ts
@@ -1,18 +1,9 @@
-// Per the design doc, this hook is the one place in `@zkpassport/ui` that
-// imports types from `@zkpassport/sdk`. The SDK is a `peerDependency` (see
-// package.json), and these are `import type` statements only — erased at
-// build time, so no runtime coupling and no impact on bundle size.
-//
-// The `sdk` parameter is typed as `ZKPassportLike` (a structural subset of
-// the `ZKPassport` class) rather than the concrete class. TypeScript treats
-// classes with private members nominally, so when the UI package's types are
-// built against one `@zkpassport/sdk` version and a consumer's app uses a
-// different one (or a locally-linked workspace copy), passing a `ZKPassport`
-// instance fails with "missing private fields" even though the runtime is
-// fine. Picking only the method we actually need drops the nominal identity.
-//
-// The vanilla / core surface stays duck-typed (see ZKPassportRequestLike in
-// core/types.ts) so non-React consumers don't need the SDK installed at all.
+// Only place in the package that imports from `@zkpassport/sdk`. Types-only,
+// erased at build, so no runtime coupling. The `sdk` parameter is typed as a
+// structural subset (`ZKPassportLike`) rather than the concrete class — TS
+// compares classes with private members nominally, so a `ZKPassport` arg
+// from a different SDK copy (workspace link, version skew) would fail with
+// "missing private fields" even when the runtime shape matches.
 
 import { useCallback, useEffect, useRef, useState } from "react"
 
@@ -20,11 +11,7 @@ import { ZKP_RETRY } from "../core/retry-bridge"
 import { ZKP_SERVICE } from "../core/service-bridge"
 import type { QueryBuilder, QueryBuilderResult, ZKPassport } from "@zkpassport/sdk"
 
-/**
- * Structural subset of `ZKPassport` that `useZKPassportRequest` actually
- * uses. Any object exposing a compatible `request(service): Promise<QueryBuilder>`
- * method satisfies this — useful for tests/mocks too.
- */
+/** Structural subset — anything with a compatible `request(service)` matches. */
 export type ZKPassportLike = Pick<ZKPassport, "request">
 
 export type UseZKPassportRequestOptions = {
@@ -37,22 +24,15 @@ export type UseZKPassportRequestOptions = {
 }
 
 /**
- * Convenience hook — owns the `await sdk.request(...).done()` boilerplate.
+ * Owns the `await sdk.request(...).done()` boilerplate. Returns `null` while
+ * preparing; the built request once resolved.
  *
- * Returns `null` while preparing; returns the built request once resolved.
- * On `deps` change or unmount, the previous in-flight build is discarded
- * (no setState after unmount; no race between two builds resolving out of order).
+ * Pass `sdk = null` while it's still being instantiated (e.g. SSR where
+ * `new ZKPassport()` waits for `useEffect`). The hook holds at `null` until
+ * a real SDK arrives.
  *
- * Pass `sdk = null` while the SDK is still being instantiated (e.g. in SSR
- * setups where `new ZKPassport()` has to wait for `useEffect` because the
- * SDK constructor reads `window.location.hostname`). The hook returns `null`
- * until a real SDK arrives, and `<QRCard>` will sit in its `preparing` state.
- *
- * `sdk`, `service`, and `query` are read live via refs, so swapping between
- * two real SDK instances doesn't trigger a rebuild on its own. Pass `deps`
- * explicitly to control when a rebuild happens. The `null` → instance
- * transition is treated as a rebuild trigger so the first request actually
- * gets built once the SDK becomes available.
+ * `sdk` / `service` / `query` are read live via refs — pass `deps` to control
+ * when a rebuild happens. The `null` → instance transition rebuilds once.
  */
 export function useZKPassportRequest(
   sdk: ZKPassportLike | null,
@@ -61,9 +41,7 @@ export function useZKPassportRequest(
   const { service, query, deps = [] } = options
 
   const [request, setRequest] = useState<QueryBuilderResult | null>(null)
-  // Bumped by the `retry` function attached to each built request. The card
-  // calls it on retry click via the hidden `ZKP_RETRY` symbol, which triggers
-  // a rebuild without the consumer needing to wire anything up.
+  // Bumped by the retry hook attached via ZKP_RETRY; re-runs the build effect.
   const [retryNonce, setRetryNonce] = useState(0)
   const retry = useCallback(() => {
     setRetryNonce((n) => n + 1)
@@ -76,16 +54,14 @@ export function useZKPassportRequest(
   serviceRef.current = service
   queryRef.current = query
 
-  // We want a null → instance transition to trigger a rebuild, but identity
-  // swaps between two real SDKs to keep going through the ref. Tracking just
-  // the presence of an SDK in the effect deps gives us both.
+  // Tracking presence (not identity) means a null → instance transition
+  // rebuilds, but identity swaps between two real SDKs don't.
   const hasSdk = sdk !== null
 
   useEffect(() => {
     let cancelled = false
-    // Flash back to `null` so consumers (e.g. <QRCard>) see the rebuild
-    // as a transition to `preparing`, rather than briefly displaying a QR
-    // pointing at a torn-down bridge.
+    // Flash back to `null` so the card transitions to `preparing` instead of
+    // briefly showing a QR pointing at a torn-down bridge.
     setRequest(null)
 
     const currentSdk = sdkRef.current
@@ -101,17 +77,14 @@ export function useZKPassportRequest(
         if (cancelled) return
         const built = queryRef.current(builder).done()
         if (cancelled) return
-        // Attach the rebuild trigger as a non-enumerable symbol property so it
-        // doesn't show up in iteration / JSON output and won't collide with
-        // any SDK field. The renderer reads it back via `readRetry()`.
+        // Non-enumerable symbol props so they don't show up in iteration /
+        // JSON output and can't collide with any SDK field. The card reads
+        // them back via `readRetry()` and `readService()`.
         Object.defineProperty(built, ZKP_RETRY, {
           value: retry,
           enumerable: false,
           configurable: true,
         })
-        // Same trick for the service strings — lets <QRCard> render its header
-        // from the data we already have, so React consumers don't have to pass
-        // `appName` / `appIcon` props in addition to declaring `service` here.
         const svc = serviceRef.current
         Object.defineProperty(built, ZKP_SERVICE, {
           value: { name: svc.name, logo: svc.logo },
@@ -121,10 +94,9 @@ export function useZKPassportRequest(
         setRequest(built)
       } catch (cause) {
         if (cancelled) return
-        // The hook's public surface is `QueryBuilderResult | null`. Surface
-        // the failure via the console so it's debuggable; downstream errors
-        // (e.g. bridge failures after the request is live) flow through
-        // <QRCard>'s `onError` callback.
+        // The public surface is `QueryBuilderResult | null` — log so the
+        // failure is debuggable. Errors after the request is live flow through
+        // `<QRCard>`'s `onError` instead.
         console.error("[@zkpassport/ui] useZKPassportRequest: failed to build request", cause)
       }
     })()
@@ -132,10 +104,9 @@ export function useZKPassportRequest(
     return () => {
       cancelled = true
     }
-    // `deps` is the canonical rebuild signal; sdk/service/query are read via
-    // refs above. `hasSdk` is included so the null → instance transition
-    // (common with SSR-deferred SDK init) triggers exactly one rebuild.
-    // `retryNonce` re-runs the effect when the card's retry button is clicked.
+    // sdk/service/query are read via refs; `deps` is the explicit rebuild
+    // signal. `hasSdk` covers the null → instance transition; `retryNonce`
+    // covers the card's retry button.
   }, [hasSdk, retryNonce, retry, ...deps])
 
   return request

--- a/packages/zkpassport-ui/src/vanilla/mount.ts
+++ b/packages/zkpassport-ui/src/vanilla/mount.ts
@@ -105,8 +105,7 @@ export function mount(element: HTMLElement, options: QRCardOptions): QRCardHandl
     // re-renders.
     const prevHeader = resolveHeader(current)
     const nextHeader = resolveHeader(next)
-    const headerChanged =
-      prevHeader.name !== nextHeader.name || prevHeader.icon !== nextHeader.icon
+    const headerChanged = prevHeader.name !== nextHeader.name || prevHeader.icon !== nextHeader.icon
     const requestChanged = current.request !== next.request
     if (!headerChanged && !requestChanged) return
 

--- a/packages/zkpassport-ui/src/vanilla/mount.ts
+++ b/packages/zkpassport-ui/src/vanilla/mount.ts
@@ -15,6 +15,7 @@ import { injectStyles } from "../core/inject-styles"
 import { generateSvg } from "../core/qr"
 import { describeVerifiedAttributes } from "../core/result-lines"
 import { readRetry } from "../core/retry-bridge"
+import { readService } from "../core/service-bridge"
 import { safeCall } from "../core/safe-call"
 import { createStateMachine, type TransitionPayload } from "../core/state"
 import type { QRCardHandle, QRCardOptions, QRCardState, ZKPassportRequestLike } from "../core/types"
@@ -52,7 +53,6 @@ type CardElements = {
  *   request: null,
  *   appName: "Your App",
  *   appIcon: "/logo.png",
- *   purpose: "Verify you're over 18",
  *   onSuccess: (r) => console.log(r),
  * })
  * // Later, once the SDK request is built:
@@ -104,11 +104,15 @@ export function mount(element: HTMLElement, options: QRCardOptions): QRCardHandl
     if (disposed) return
 
     const next: QRCardOptions = { ...current, ...partial }
-    // `theme` and `purpose` are accepted on the type but not rendered (theme is
-    // light-only in v1, purpose is forwarded to `sdk.request(...)` but not
-    // shown in the card). Callbacks are read live by the state machine via a
-    // getter, so handler-only changes need no work here.
-    const headerChanged = current.appName !== next.appName || current.appIcon !== next.appIcon
+    // `theme` is accepted on the type but not rendered (light-only in v1).
+    // Callbacks are read live by the state machine via a getter, so
+    // handler-only changes need no work here. The header diff compares the
+    // *resolved* values (props ?? attached-service) so a `request` swap that
+    // brings a different service still triggers a re-render.
+    const prevHeader = resolveHeader(current)
+    const nextHeader = resolveHeader(next)
+    const headerChanged =
+      prevHeader.name !== nextHeader.name || prevHeader.icon !== nextHeader.icon
     const requestChanged = current.request !== next.request
     if (!headerChanged && !requestChanged) return
 
@@ -117,6 +121,14 @@ export function mount(element: HTMLElement, options: QRCardOptions): QRCardHandl
 
     if (headerChanged) renderHeader()
     if (requestChanged) handleRequestChange(prevRequest, current.request)
+  }
+
+  function resolveHeader(opts: QRCardOptions): { name: string; icon: string } {
+    const attached = readService(opts.request)
+    return {
+      name: opts.appName ?? attached?.name ?? "",
+      icon: opts.appIcon ?? attached?.logo ?? "",
+    }
   }
 
   function unmount() {
@@ -159,10 +171,14 @@ export function mount(element: HTMLElement, options: QRCardOptions): QRCardHandl
   }
 
   function renderHeader() {
-    elements.appName.textContent = current.appName
-    if (current.appIcon) {
-      elements.appIcon.src = current.appIcon
-      elements.appIcon.alt = `${current.appName} icon`
+    const { name, icon } = resolveHeader(current)
+    // Fall back to "This app" so the title sentence still reads naturally
+    // during the brief `preparing` window where the hook hasn't built the
+    // request yet (no attached service) and no `appName` prop was passed.
+    elements.appName.textContent = name || "This app"
+    if (icon) {
+      elements.appIcon.src = icon
+      elements.appIcon.alt = name ? `${name} icon` : ""
       elements.appIcon.style.display = ""
     } else {
       elements.appIcon.removeAttribute("src")

--- a/packages/zkpassport-ui/src/vanilla/mount.ts
+++ b/packages/zkpassport-ui/src/vanilla/mount.ts
@@ -20,9 +20,7 @@ import { safeCall } from "../core/safe-call"
 import { createStateMachine, type TransitionPayload } from "../core/state"
 import type { QRCardHandle, QRCardOptions, QRCardState, ZKPassportRequestLike } from "../core/types"
 
-// Duration (per leg) of the body crossfade between states. Fade-out and
-// fade-in run sequentially around the content swap, so the total motion is
-// ~2× this value — matched roughly to the height animation below.
+// Per leg — fade-out and fade-in run sequentially, so total motion is ~2× this.
 const FADE_DURATION_MS = 500
 
 type CardElements = {
@@ -70,26 +68,23 @@ export function mount(element: HTMLElement, options: QRCardOptions): QRCardHandl
 
   injectStyles()
 
-  // Working copy of the options — `update()` mutates this in place after diffing.
-  // `theme` is currently accepted but ignored (v1 is light-only); see styles.css
-  // for the steps to re-enable dark mode.
+  // Working copy of the options — `update()` reassigns after diffing.
   let current: QRCardOptions = { ...options }
 
   const elements = buildDom()
   element.appendChild(elements.root)
 
-  // Tracks the QR generation job so a stale Promise (from a request that was
-  // replaced before its SVG resolved) doesn't overwrite the live QR.
+  // Bumped on each renderQr() call so a late-resolving stale Promise doesn't
+  // overwrite the live QR.
   let qrToken = 0
 
   const machine = createStateMachine({
-    // Read live from `current` so handler changes via update() are picked up
-    // at fire time without an explicit setCallbacks round-trip.
+    // Live-read so handler changes via update() are picked up at fire time
+    // without an explicit setCallbacks round-trip.
     getCallbacks: () => current,
     onTransition: renderState,
   })
 
-  // Initial paint and event wiring.
   renderHeader()
   if (current.request !== null) {
     void renderQr(current.request)
@@ -104,11 +99,10 @@ export function mount(element: HTMLElement, options: QRCardOptions): QRCardHandl
     if (disposed) return
 
     const next: QRCardOptions = { ...current, ...partial }
-    // `theme` is accepted on the type but not rendered (light-only in v1).
-    // Callbacks are read live by the state machine via a getter, so
-    // handler-only changes need no work here. The header diff compares the
-    // *resolved* values (props ?? attached-service) so a `request` swap that
-    // brings a different service still triggers a re-render.
+    // Callbacks are read live by the state machine, and `theme` is unused in
+    // v1, so we only diff what actually drives DOM. Header diff uses *resolved*
+    // values so a request swap bringing different attached service still
+    // re-renders.
     const prevHeader = resolveHeader(current)
     const nextHeader = resolveHeader(next)
     const headerChanged =
@@ -158,23 +152,20 @@ export function mount(element: HTMLElement, options: QRCardOptions): QRCardHandl
   }
 
   function handleRetryClick() {
-    // Pop the UI back to the QR-scanning step first so the user sees instant
-    // feedback while the new request is being built.
+    // Pop back to the QR step first so the user sees instant feedback while
+    // the new request is being built.
     machine.retry()
-
-    // If the request was built via `useZKPassportRequest`, it carries a hidden
-    // retry hook — invoking it tells the hook to rebuild and emit a new
-    // request, which flows back through `update({ request })`. This is what
-    // makes auto-retry work out of the box for React consumers.
+    // `readRetry` triggers the hook to rebuild and emit a new request via
+    // `update({ request })`. Vanilla consumers wire the rebuild themselves
+    // through `onRetryClicked`.
     safeCall(readRetry(current.request))
     safeCall(current.onRetryClicked)
   }
 
   function renderHeader() {
     const { name, icon } = resolveHeader(current)
-    // Fall back to "This app" so the title sentence still reads naturally
-    // during the brief `preparing` window where the hook hasn't built the
-    // request yet (no attached service) and no `appName` prop was passed.
+    // Fallback keeps the title sentence readable during the brief preparing
+    // window when the hook hasn't built the request yet.
     elements.appName.textContent = name || "This app"
     if (icon) {
       elements.appIcon.src = icon
@@ -197,8 +188,8 @@ export function mount(element: HTMLElement, options: QRCardOptions): QRCardHandl
       elements.qrLogo.style.display = ZKPASSPORT_LOGO ? "grid" : "none"
     } catch (cause) {
       if (myToken !== qrToken || disposed) return
-      // Route through the state machine so the UI transitions to `error`
-      // instead of being left stuck on whatever state it was in.
+      // Route through the machine so the UI transitions to `error` instead of
+      // being stuck on whatever state it was in.
       machine.fail("unknown", "Failed to generate QR code", cause)
     }
   }
@@ -210,28 +201,22 @@ export function mount(element: HTMLElement, options: QRCardOptions): QRCardHandl
     elements.openAppLink.removeAttribute("href")
   }
 
-  // Tracks the in-flight height-animation generation so a transition that gets
-  // superseded by a newer state change doesn't clear the newer transition's
-  // inline styles when its own `transitionend` finally fires.
+  // Tokens guarding superseded animations: an in-flight handler checks its
+  // token against the live one and bails if it's stale. Without this, a fast
+  // state swap mid-transition lets the older handler clobber the newer one.
   let heightAnimToken = 0
-
-  // Token guarding the crossfade choreography. A state change that arrives
-  // mid-fade bumps the token; the in-flight fade-out's `finish` listener checks
-  // it and bails so the superseded transition doesn't apply stale mutations or
-  // start a fade-in on an element the new transition is about to fade out.
   let fadeToken = 0
 
   function renderState(state: QRCardState, payload?: TransitionPayload) {
     const apply = () => applyStateContent(state, payload)
     const prevState = elements.root.getAttribute("data-state") as QRCardState | null
 
-    // Reduced motion: skip every animation and apply the new content straight.
     if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
       apply()
       return
     }
 
-    // First paint (no prior data-state): no crossfade — just animate height.
+    // First paint: no crossfade, just animate height.
     if (prevState === null) {
       animateHeight(elements.root, apply)
       return
@@ -271,14 +256,13 @@ export function mount(element: HTMLElement, options: QRCardOptions): QRCardHandl
 
     switch (state) {
       case "preparing":
-        // Skeleton is purely CSS-driven via the [data-state="preparing"] selector.
+        // Skeleton is CSS-driven via [data-state="preparing"].
         break
       case "connecting":
         appendSpinner(elements.overlayBody)
         elements.overlayText.textContent = "Connecting…"
         break
       case "waiting":
-        // No overlay — the QR itself is the call to action.
         break
       case "scanned":
         appendConfirmationImage(elements.overlayBody)
@@ -303,10 +287,8 @@ export function mount(element: HTMLElement, options: QRCardOptions): QRCardHandl
     }
   }
 
-  // The "body" of the card swaps between the QR slot (pre-result states) and
-  // the result panel (success / error). The crossfade runs on whichever is the
-  // currently visible body — siblings, not nested — so a transition that
-  // crosses the qr-slot/result-panel boundary still reads as one fade.
+  // QR slot pre-result, result panel for success/error. They're siblings (not
+  // nested) so a fade across the boundary still reads as one transition.
   function pickBody(state: QRCardState): HTMLElement {
     return state === "success" || state === "error" ? elements.resultPanel : elements.qrSlot
   }
@@ -317,18 +299,9 @@ export function mount(element: HTMLElement, options: QRCardOptions): QRCardHandl
     }
   }
 
-  /**
-   * Animate the card's bottom edge between two natural heights.
-   *
-   * Synchronous flow (no paint between steps):
-   *   1. read pre-change height
-   *   2. run `apply` (DOM mutations — browser recomputes layout but does not paint)
-   *   3. read post-change natural height
-   *   4. lock the card to the pre-change height, then animate to the new one
-   *
-   * Reduced-motion is handled by the caller (`renderState`); this function
-   * always animates.
-   */
+  // Animate the card's bottom edge between two natural heights. Reads/writes
+  // happen synchronously around `apply` so the browser doesn't paint the new
+  // height before the lock takes effect. Caller handles reduced motion.
   function animateHeight(el: HTMLElement, apply: () => void, duration = 280) {
     const before = el.offsetHeight
     apply()
@@ -338,8 +311,7 @@ export function mount(element: HTMLElement, options: QRCardOptions): QRCardHandl
     const token = ++heightAnimToken
     el.style.transition = "none"
     el.style.height = `${before}px`
-    // Force the browser to commit the locked height before kicking off the
-    // transition; without this read, both height writes coalesce and the
+    // Forced reflow: without this read, both height writes coalesce and the
     // transition has nothing to animate from.
     void el.offsetHeight
     el.style.transition = `height ${duration}ms ease`
@@ -348,8 +320,7 @@ export function mount(element: HTMLElement, options: QRCardOptions): QRCardHandl
     const onEnd = (event: TransitionEvent) => {
       if (event.target !== el || event.propertyName !== "height") return
       el.removeEventListener("transitionend", onEnd)
-      // A newer animation has taken over and already set fresh inline styles —
-      // clearing them here would undo its lock.
+      // Newer animation already set fresh inline styles — don't clobber.
       if (token !== heightAnimToken) return
       el.style.height = ""
       el.style.transition = ""
@@ -361,7 +332,6 @@ export function mount(element: HTMLElement, options: QRCardOptions): QRCardHandl
     const root = document.createElement("div")
     root.className = "zkp-card"
 
-    // Header: app icon ⋯ ZKPassport globe, then a one-line tagline.
     const header = document.createElement("div")
     header.className = "zkp-header"
 
@@ -381,9 +351,8 @@ export function mount(element: HTMLElement, options: QRCardOptions): QRCardHandl
     zkpIcon.innerHTML = ICON_GLOBE
     headerIcons.append(zkpIcon, dots, appIcon)
 
-    // Title is intentionally generic — the consumer's `purpose` prop is still
-    // forwarded to `sdk.request(...)` but not shown here, so the card reads
-    // the same across every integration.
+    // Title is intentionally generic — the card reads the same across every
+    // integration. `purpose` is shown to the user inside the mobile app, not here.
     const title = document.createElement("p")
     title.className = "zkp-title"
     const appName = document.createElement("strong")
@@ -396,16 +365,13 @@ export function mount(element: HTMLElement, options: QRCardOptions): QRCardHandl
       document.createTextNode(" to verify identity without compromising your privacy."),
     )
 
-    // Shown only during the `scanned` state — swapped in for the tagline so the
-    // user sees a direct prompt while approving on their phone. CSS in the
-    // `[data-state="scanned"]` block toggles visibility between the two.
+    // Shown only during `scanned` — CSS toggles visibility against the tagline.
     const approvalMessage = document.createElement("p")
     approvalMessage.className = "zkp-approval-message"
     approvalMessage.textContent = "Approve the request on your phone"
 
     header.append(headerIcons, title, approvalMessage)
 
-    // QR
     const qrSlot = document.createElement("div")
     qrSlot.className = "zkp-qr-slot"
     qrSlot.setAttribute("data-state", "preparing")
@@ -425,10 +391,8 @@ export function mount(element: HTMLElement, options: QRCardOptions): QRCardHandl
     overlay.append(overlayBody, overlayText)
     qrSlot.append(skeleton, qrContainer, qrLogo, overlay)
 
-    // Deep-link CTA shown only on touch devices during the `waiting` state —
-    // taps the request URL directly into the ZKPassport app instead of asking
-    // the user to scan their own screen. Visibility is CSS-driven (see
-    // `.zkp-open-app` rules in styles.css).
+    // Deep-link CTA shown only on touch devices during `waiting`. Visibility
+    // is CSS-driven (`.zkp-open-app` in styles.css).
     const openAppLink = document.createElement("a")
     openAppLink.className = "zkp-open-app"
     openAppLink.textContent = "Open in ZKPassport App"
@@ -439,8 +403,7 @@ export function mount(element: HTMLElement, options: QRCardOptions): QRCardHandl
     retry.textContent = "Try again"
     retry.addEventListener("click", handleRetryClick)
 
-    // Result panel — replaces the QR slot during the `success` / `error`
-    // terminal states. Built once and toggled via CSS on the card's data-state.
+    // Built once; CSS swaps it in for the QR slot during `success` / `error`.
     const resultPanel = document.createElement("div")
     resultPanel.className = "zkp-result-panel"
     const resultIcon = document.createElement("div")
@@ -453,7 +416,6 @@ export function mount(element: HTMLElement, options: QRCardOptions): QRCardHandl
     resultActions.className = "zkp-result-actions"
     resultPanel.append(resultIcon, resultTitle, resultLines, resultActions)
 
-    // Steps: download, scan, approve.
     const dividerTop = document.createElement("div")
     dividerTop.className = "zkp-divider zkp-divider-top"
 
@@ -471,7 +433,6 @@ export function mount(element: HTMLElement, options: QRCardOptions): QRCardHandl
     const dividerBottom = document.createElement("div")
     dividerBottom.className = "zkp-divider zkp-divider-bottom"
 
-    // Footer: label + store buttons (placeholder URLs).
     const footer = document.createElement("div")
     footer.className = "zkp-footer"
     const footerLabel = document.createElement("span")
@@ -556,9 +517,8 @@ function appendSpinner(parent: HTMLElement) {
   parent.appendChild(el)
 }
 
-// Three concentric ring pairs (A/B fade against each other on opposite phase)
-// driven by CSS animations declared in styles.css. Gradient IDs are namespaced
-// to avoid colliding with consumer SVGs sharing the same document.
+// Three concentric ring pairs, animated via CSS in styles.css. Gradient IDs
+// are namespaced so they don't collide with consumer SVGs.
 const SPINNER_SVG = `
 <svg width="100%" height="100%" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
   <defs>


### PR DESCRIPTION
## Summary

- Hook consumers no longer pass `appName` / `appIcon` props in addition to declaring `service` — `useZKPassportRequest` attaches `{ name, logo }` to the built request under a hidden symbol (`core/service-bridge.ts`); the card reads it as a fallback.
- Drops `purpose` from `<QRCard>` props (the card never rendered it; still passed to `sdk.request(...)` for display in the mobile app).
- Vanilla consumers keep passing `appName` / `appIcon` props (now typed optional); when neither is provided, the title falls back to "This app uses ZKPassport…" so the brief preparing state stays readable.

The minimal React integration becomes:

```tsx
const [sdk] = useState(() => new ZKPassport(window.location.hostname))
const request = useZKPassportRequest(sdk, { service, query: (b) => b.gte("age", 18) })
return <QRCard request={request} onSuccess={...} />
```

When the SDK exposes `service` on `QueryBuilderResult` (0.15.0 — see "Future improvements" in the design doc), `core/service-bridge.ts` can be deleted in favor of reading the field directly. No breaking change to consumers.

## Test plan

- [ ] `bun run build` produces fresh ESM + CJS + types
- [ ] Linked test app (`qr-code-react-test`) renders the minimal `<QRCard request={request} onSuccess={…} />` form
- [ ] Header shows app name + logo once the hook resolves the request
- [ ] Vanilla `mount()` consumers that pass `appName` / `appIcon` still render the header on first paint (before any request is attached)
- [ ] When neither prop nor attached service is available, the title shows "This app uses ZKPassport…" instead of " uses ZKPassport…"
- [ ] Retry button still rebuilds the request (the `ZKP_RETRY` bridge keeps working unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)