### PR TITLE
feat(workspace): Prepare @zkpassport/ui for npm publish (PR 5/5)

### DIFF
--- a/.github/workflows/publish-zkpassport-ui.yml
+++ b/.github/workflows/publish-zkpassport-ui.yml
@@ -1,0 +1,89 @@
+name: Publish ZKPassport UI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - packages/zkpassport-ui/package.json
+
+jobs:
+  publish:
+    name: Publish UI
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    permissions:
+      id-token: write  # Required for OIDC
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.8
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Ensure workspace dependencies are synced
+        run: bash scripts/sync-workspace-deps.sh check
+
+      - name: Install system dependencies
+        run: sudo apt-get install -y lsof jq zsh
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: v1.4.4
+
+      - name: Install Foundry dependencies
+        run: forge install
+        working-directory: packages/registry-contracts
+
+      - name: Setup Turbo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
+      - name: Build package
+        run: bun run build --filter=@zkpassport/ui
+
+      - name: Setup Node.js for npm publish
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Check if version is published to npm
+        id: version_check
+        run: |
+          VERSION=$(node -p "require('./packages/zkpassport-ui/package.json').version")
+          if ! npm view @zkpassport/ui@$VERSION version 2>/dev/null; then
+            echo "publish=true" >> $GITHUB_OUTPUT
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Publish new version to npm
+        if: steps.version_check.outputs.publish == 'true'
+        run: |
+          ../../scripts/prepublish.sh
+          PKG=$(bun pm pack --quiet | xargs)
+          if [[ "${{ steps.version_check.outputs.version }}" =~ [0-9]+\.[0-9]+\.[0-9]+\- ]]; then
+            npm publish "$PKG" --ignore-scripts --provenance --access public --tag beta
+          else
+            npm publish "$PKG" --ignore-scripts --provenance --access public
+          fi
+        working-directory: packages/zkpassport-ui

--- a/.github/workflows/publish-zkpassport-ui.yml
+++ b/.github/workflows/publish-zkpassport-ui.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get install -y lsof jq zsh
 
+      # Foundry is required by the later "Publish" step, not the filtered
+      # build below: scripts/prepublish.sh runs `bun run build` workspace-wide,
+      # which invokes `forge build` in packages/registry-contracts.
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:

--- a/packages/zkpassport-ui/README.md
+++ b/packages/zkpassport-ui/README.md
@@ -1,0 +1,61 @@
+# ZKPassport UI
+
+Drop-in QR verification card for [ZKPassport](https://zkpassport.id). Renders the QR, owns the visual state machine (preparing → connecting → waiting → scanned → generating → success/error), and lets you wire a verification flow in one mount.
+
+## Installation
+
+```sh
+npm install @zkpassport/ui @zkpassport/sdk
+```
+
+`@zkpassport/sdk` is a peer dependency. React is optional — pull it in if you use the `<QRCard>` component or `useZKPassportRequest` hook.
+
+## Usage
+
+```tsx
+import { useState } from "react"
+import { ZKPassport } from "@zkpassport/sdk"
+import { QRCard, useZKPassportRequest } from "@zkpassport/ui"
+
+function App() {
+  // `useState` (not `useMemo`) so React keeps the same instance.
+  const [sdk] = useState(() => new ZKPassport(window.location.hostname))
+
+  const request = useZKPassportRequest(sdk, {
+    service: {
+      name: "QR Test App",
+      logo: "https://zkpassport.id/favicon.png",
+      purpose: "Verify you're over 18",
+    },
+    query: (b) => b.gte("age", 18),
+  })
+
+  return (
+    <QRCard
+      request={request}
+      onSuccess={(r) => console.log(r)}
+      onError={console.error}
+    />
+  )
+}
+```
+
+The hook returns `null` while it builds the request — the card renders its body immediately and swaps the QR area's skeleton for the QR once `request` is non-null.
+
+In Next.js App Router, mark the file with `"use client"` so the card renders on the client. The package's React entry is also marked `"use client"`, so importing from a server component yields a clear error.
+
+## Sizing
+
+The card is fluid within bounds: fills its container width up to `max-width: 350px` and refuses to shrink below `min-width: 280px`. Control placement and outer margins by sizing the parent.
+
+## CSS
+
+Styles are auto-injected as a `<style>` tag wrapped in `@layer zkpassport`, so host app styles in the default cascade always win. CSP-strict consumers can opt out of inline styles by importing the standalone bundle:
+
+```ts
+import "@zkpassport/ui/styles.css"
+```
+
+## License
+
+Apache-2.0

--- a/packages/zkpassport-ui/README.md
+++ b/packages/zkpassport-ui/README.md
@@ -44,10 +44,6 @@ The hook returns `null` while it builds the request — the card renders its bod
 
 In Next.js App Router, mark the file with `"use client"` so the card renders on the client. The package's React entry is also marked `"use client"`, so importing from a server component yields a clear error.
 
-## Sizing
-
-The card is fluid within bounds: fills its container width up to `max-width: 350px` and refuses to shrink below `min-width: 280px`. Control placement and outer margins by sizing the parent.
-
 ## CSS
 
 Styles are auto-injected as a `<style>` tag wrapped in `@layer zkpassport`, so host app styles in the default cascade always win. CSP-strict consumers can opt out of inline styles by importing the standalone bundle:

--- a/packages/zkpassport-ui/package.json
+++ b/packages/zkpassport-ui/package.json
@@ -1,8 +1,6 @@
 {
   "name": "@zkpassport/ui",
   "version": "0.1.0-beta.0",
-  "// private": "Stays true while the package is stubbed. Flip to false (or remove) once PR 2/3 land real implementations and we're ready to publish 0.1.0-beta.0.",
-  "private": true,
   "description": "Drop-in QR verification card for ZKPassport. Works in React and any bundler-based stack (Vue/Svelte/Solid/Astro/vanilla JS) via the /vanilla entry.",
   "author": "ZKPassport",
   "license": "Apache-2.0",
@@ -57,6 +55,7 @@
   ],
   "keywords": [
     "zkpassport",
+    "zkpassport-ui",
     "ui",
     "react",
     "qrcode",

--- a/scripts/sync-workspace-deps.sh
+++ b/scripts/sync-workspace-deps.sh
@@ -9,6 +9,7 @@ set -e
 echo "Ensuring workspace dependencies are synced"
 (cd packages/zkpassport-sdk && bun update @zkpassport/utils @zkpassport/registry)
 (cd packages/registry-sdk && bun update @zkpassport/utils)
+(cd packages/zkpassport-ui && bun update @zkpassport/sdk)
 
 # Check mode for CI: verify that workspace dependencies are synced
 # If bun.lock has changed, then the dependencies are not synced


### PR DESCRIPTION
## Summary

Final PR in the `@zkpassport/ui` v0.1 series. Wires up the publish pipeline so the package can ship to npm under `@zkpassport/ui@0.1.0-beta.0` via the `beta` tag. No further `npm publish` step needed — merge to `main` triggers the workflow.

- Drop `"private": true` publish guard from `package.json`
- Add `.github/workflows/publish-zkpassport-ui.yml` mirroring [publish-zkpassport-sdk.yml](.github/workflows/publish-zkpassport-sdk.yml) and [publish-zkpassport-utils.yml](.github/workflows/publish-zkpassport-utils.yml) — OIDC against the `npm-publish` environment, auto-routes prerelease versions to the `beta` tag
- Add `README.md` as the npm landing page (minimal React example modeled on a real consumer integration)
- Register the ui package in [scripts/sync-workspace-deps.sh](scripts/sync-workspace-deps.sh) so its workspace-dep on `@zkpassport/sdk` stays in sync with `bun.lock` and the `dependency-sync-check` CI job covers it
- Add `zkpassport-ui` keyword to match the discoverability convention used by `@zkpassport/sdk` (`zkpassport-sdk`) and `@zkpassport/utils` (`zkpassport-utils`)

## Test plan

- [x] `bun run build` — ESM + CJS + types + `styles.css` emit cleanly
- [x] `bun pm pack` — tarball ships only `LICENSE`, `README.md`, `package.json`, `dist/` (548 KB; no source/tests/maps-of-source leak)
- [x] `bun run validate-package` — publint clean; attw green for `node16 (CJS)`, `node16 (ESM)`, and `bundler` on both `.` and `./vanilla` entries
- [x] `bash scripts/sync-workspace-deps.sh check` — passes (no `bun.lock` drift)
- [ ] After merge to `main`: confirm `Publish ZKPassport UI` workflow run completes and `npm view @zkpassport/ui@0.1.0-beta.0` resolves

## Manager handoff

The `npm publish` is automated by the workflow once this lands on `main`. The only manual step is confirming the `npm-publish` GitHub environment can publish under the `@zkpassport` npm scope — the sdk/utils workflows already use this environment, so it's almost certainly already configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)