### PR TITLE
fix(sdk): Address policy review feedback

### DIFF
--- a/packages/zkpassport-sdk/README.md
+++ b/packages/zkpassport-sdk/README.md
@@ -113,34 +113,6 @@ onResult(
 )
 ```
 
-### Using a policy
-
-The ZKPassport dashboard is an **optional convenience layer**. You can use the SDK fully self-served (passing `name`, `logo`, `purpose` directly to `request()`) without depending on the dashboard. If you'd rather manage verification parameters and branding in one place, register your domain on the dashboard and reference a **policy** by id.
-
-A policy is an immutable, versioned bundle of query configuration belonging to your domain. Every `request()` call best-effort fetches your per-domain dashboard config (branding + policies). The fetch is cached for the lifetime of the `ZKPassport` instance, so it only hits the network once. If the dashboard is unreachable and you didn't request a policy, the failure is swallowed silently and the request still goes out with your self-serve fields.
-
-Apply a policy by chaining `.policy('<id>')` on the builder returned by `request()`:
-
-```ts
-// Defaults: name/logo come from the dashboard branding for your domain,
-// purpose/scope come from the policy.
-const { url, onResult } = (await zkPassport.request()).policy("pol_xyz").done()
-
-// Override branding per-request (white-label).
-const { url, onResult } = (
-  await zkPassport.request({ name: "My Brand", logo: "https://my.brand/logo.png" })
-)
-  .policy("pol_xyz")
-  .done()
-```
-
-Rules:
-
-- The policy locks the query, purpose and scope: `.gte()`, `.disclose()`, `.eq()` etc. throw if combined with `.policy()` (in either order), and per-request `purpose`/`scope` are ignored.
-- `name`/`logo` default to the dashboard branding for your domain. Pass `name`/`logo` to `request()` to override them per-request (white-label).
-- `scope` is fixed to `<policyId>:<version>`, so proofs from different policy versions stay filterable apart.
-- The result includes a `policy` field (the policy id) for surfacing in your UI / logs.
-
 ### Using with Next.js
 
 You can integrate `@zkpassport/sdk` into a Next.js application by creating a backend API route and calling it from your frontend.

--- a/packages/zkpassport-sdk/README.md
+++ b/packages/zkpassport-sdk/README.md
@@ -126,10 +126,9 @@ Apply a policy by chaining `.policy('<id>')` on the builder returned by `request
 // purpose/scope come from the policy.
 const { url, onResult } = (await zkPassport.request()).policy("pol_xyz").done()
 
-// Override any field by passing it to `request()` — caller wins per field,
-// policy fills in whatever you omit.
+// Override branding per-request (white-label).
 const { url, onResult } = (
-  await zkPassport.request({ purpose: "Custom purpose for this flow" })
+  await zkPassport.request({ name: "My Brand", logo: "https://my.brand/logo.png" })
 )
   .policy("pol_xyz")
   .done()
@@ -137,11 +136,10 @@ const { url, onResult } = (
 
 Rules:
 
-- The policy locks the query: `.gte()`, `.disclose()`, `.eq()` etc. throw if combined with `.policy()` (in either order).
-- `name`/`logo` default to the dashboard branding for your domain; `purpose` defaults to the policy's purpose. Per-request `name`/`logo`/`purpose`/`scope`/`validity`/`mode`/`devMode` passed to `request()` override these.
-- `scope` defaults to `<policyId>@v<version>` when not provided, so proofs from different policy versions stay filterable apart.
-- The result includes a `policy: { id, version }` field for surfacing in your UI / logs.
-- Each `request()` triggers at most one successful `GET https://dashboard-api.zkpassport.id/public/app?domain=<domain>` per `ZKPassport` instance. A failed fetch is silently swallowed; calling `.policy()` afterwards re-throws the fetch error so the caller sees a meaningful message.
+- The policy locks the query, purpose and scope: `.gte()`, `.disclose()`, `.eq()` etc. throw if combined with `.policy()` (in either order), and per-request `purpose`/`scope` are ignored.
+- `name`/`logo` default to the dashboard branding for your domain. Pass `name`/`logo` to `request()` to override them per-request (white-label).
+- `scope` is fixed to `<policyId>:<version>`, so proofs from different policy versions stay filterable apart.
+- The result includes a `policy` field (the policy id) for surfacing in your UI / logs.
 
 ### Using with Next.js
 

--- a/packages/zkpassport-sdk/src/dashboard-api.ts
+++ b/packages/zkpassport-sdk/src/dashboard-api.ts
@@ -1,6 +1,6 @@
 import type { ProofResult, QueryResult } from "@zkpassport/utils"
 import { DASHBOARD_API_BASE_URL, VERSION } from "./constants"
-import { customLogger as logger } from "./logger"
+import { noLogger as logger } from "./logger"
 
 /** Fire-and-forget: errors are logged, never thrown. */
 export async function submitProof({

--- a/packages/zkpassport-sdk/src/dashboard-api.ts
+++ b/packages/zkpassport-sdk/src/dashboard-api.ts
@@ -1,4 +1,4 @@
-import type { ProofResult, QueryResult } from "@zkpassport/utils"
+import type { ProofResult, Query, QueryResult } from "@zkpassport/utils"
 import { DASHBOARD_API_BASE_URL, VERSION } from "./constants"
 import { noLogger as logger } from "./logger"
 
@@ -6,14 +6,14 @@ import { noLogger as logger } from "./logger"
 export async function submitProof({
   domain,
   proofs,
+  query,
   queryResult,
-  uniqueIdentifier,
   scope,
 }: {
   domain: string
   proofs: Array<ProofResult>
+  query: Query
   queryResult: QueryResult
-  uniqueIdentifier: string | undefined
   scope: string | undefined
 }) {
   const payload = proofs.map((p) => ({
@@ -32,8 +32,8 @@ export async function submitProof({
       body: JSON.stringify({
         domain,
         proofs: payload,
+        query,
         queryResult,
-        uniqueIdentifier,
         scope,
         sdkVersion: VERSION,
       }),

--- a/packages/zkpassport-sdk/src/dashboard-api.ts
+++ b/packages/zkpassport-sdk/src/dashboard-api.ts
@@ -1,6 +1,6 @@
 import type { ProofResult, QueryResult } from "@zkpassport/utils"
 import { DASHBOARD_API_BASE_URL, VERSION } from "./constants"
-import { noLogger as logger } from "./logger"
+import { customLogger as logger } from "./logger"
 
 /** Fire-and-forget: errors are logged, never thrown. */
 export async function submitProof({

--- a/packages/zkpassport-sdk/src/index.ts
+++ b/packages/zkpassport-sdk/src/index.ts
@@ -153,6 +153,7 @@ export class ZKPassport {
   private topicToBridge: Record<string, BridgeInterface> = {}
   private topicToRequestReceived: Record<string, boolean> = {}
   private topicToService: Record<string, Service> = {}
+  private topicToCallerPurpose: Record<string, string | undefined> = {}
   private topicToProofs: Record<string, Array<ProofResult>> = {}
   private topicToFailedProofCount: Record<string, number> = {}
   private topicToResults: Record<string, QueryResult> = {}
@@ -460,10 +461,12 @@ export class ZKPassport {
         }
         const policy = this.findPolicy(this.dashboardConfig, id)
         this.topicToConfig[topic] = policy.query
-        // Policy locks purpose and scope — caller overrides via request() are ignored.
+        // Policy locks scope; caller's purpose still wins when provided.
         const svc = this.topicToService[topic]
         if (svc) {
-          svc.purpose = policy.purpose || DEFAULT_PURPOSE
+          if (!this.topicToCallerPurpose[topic]) {
+            svc.purpose = policy.purpose || DEFAULT_PURPOSE
+          }
           svc.scope = policyScope(policy)
         }
         this.topicToPolicy[topic] = { id: policy.id, version: policy.version }
@@ -599,10 +602,10 @@ export class ZKPassport {
 
   /**
    * @notice Create a new request. To apply a policy, chain `.policy('<id>')` on
-   * the returned builder; a policy locks query, purpose and scope.
+   * the returned builder; a policy locks the query and scope.
    * @param name Your service name. Defaults to the dashboard branding, then the domain.
    * @param logo Your service logo. Defaults to the dashboard branding.
-   * @param purpose Explanation shown to the user. Defaults to a generic message. Locked by `.policy()`.
+   * @param purpose Explanation shown to the user. Defaults to the policy's purpose (if any), then a generic message.
    * @param scope Use-case scope (drives the nullifier). Defaults to the domain. Locked by `.policy()` (to `<id>:<version>`).
    * @param projectID The project ID of your service
    * @param validity How many seconds ago the proof checking the expiry date of the ID should have been generated
@@ -662,6 +665,7 @@ export class ZKPassport {
     const topic = bridge.connection.getBridgeId()
 
     this.topicToConfig[topic] = {}
+    this.topicToCallerPurpose[topic] = purpose
     this.topicToService[topic] = {
       name: name || config?.project?.name || this.domain,
       logo: logo || config?.project?.logoUrl || "",

--- a/packages/zkpassport-sdk/src/index.ts
+++ b/packages/zkpassport-sdk/src/index.ts
@@ -537,7 +537,7 @@ export class ZKPassport {
   }
 
   private async fetchDashboardConfig(): Promise<DashboardConfig> {
-    const url = `${DASHBOARD_API_BASE_URL}/public/app?domain=${encodeURIComponent(this.domain)}`
+    const url = `${DASHBOARD_API_BASE_URL}/public/project?domain=${encodeURIComponent(this.domain)}`
     let response: Response
     try {
       response = await fetch(url, { signal: AbortSignal.timeout(10000) })
@@ -557,7 +557,7 @@ export class ZKPassport {
       )
     }
     const config = (await response.json()) as DashboardConfig
-    if (!config || !config.app || !Array.isArray(config.policies)) {
+    if (!config || !config.project || !Array.isArray(config.policies)) {
       throw new Error(`Invalid dashboard config response for domain '${this.domain}'`)
     }
     return config
@@ -663,8 +663,8 @@ export class ZKPassport {
 
     this.topicToConfig[topic] = {}
     this.topicToService[topic] = {
-      name: name || config?.app?.name || this.domain,
-      logo: logo || config?.app?.logoUrl || "",
+      name: name || config?.project?.name || this.domain,
+      logo: logo || config?.project?.logoUrl || "",
       purpose: purpose || DEFAULT_PURPOSE,
       scope: scope || this.domain,
       projectID,

--- a/packages/zkpassport-sdk/src/index.ts
+++ b/packages/zkpassport-sdk/src/index.ts
@@ -20,7 +20,6 @@ import {
   getProofData,
   getNumberOfPublicInputs,
   formatQueryResultDates,
-  OPRF_DEFAULT_KEY_ID,
 } from "@zkpassport/utils"
 import { noLogger as logger } from "./logger"
 import i18en from "i18n-iso-countries/langs/en.json"
@@ -51,11 +50,11 @@ if (typeof globalThis.Buffer === "undefined") {
 
 registerLocale(i18en)
 
-// Combines policy id and version into the scope string committed into proofs.
-// Including the version keeps proofs from different policy versions filterable apart.
 function policyScope(policy: { id: string; version: number }): string {
-  return `${policy.id}@v${policy.version}`
+  return `${policy.id}:${policy.version}`
 }
+
+const DEFAULT_PURPOSE = "Verify identity privately"
 
 function normalizeCountry(country: CountryName | Alpha3Code) {
   if (country === "Zero Knowledge Republic") {
@@ -158,19 +157,6 @@ export class ZKPassport {
   private topicToFailedProofCount: Record<string, number> = {}
   private topicToResults: Record<string, QueryResult> = {}
   private topicToPolicy: Record<string, { id: string; version: number }> = {}
-  // Raw caller-supplied request() values for fields that the policy can also
-  // provide and whose defaults are indistinguishable from caller input
-  // (validity=DEFAULT_VALIDITY, mode="fast", devMode=false). Read by .policy()
-  // to merge with caller-wins semantics. purpose/scope use topicToService as
-  // ground truth — "" / undefined there means "not caller-supplied".
-  private topicToCallerArgs: Record<
-    string,
-    { validity?: number; mode?: ProofMode; devMode?: boolean }
-  > = {}
-  // Cached dashboard config. The promise guards against parallel request()
-  // calls firing two fetches; it's cleared on failure so the next call retries.
-  // dashboardConfigError holds the most recent fetch failure so `.policy()` can
-  // surface it (the request() body swallows it for self-serve callers).
   private dashboardConfig: DashboardConfig | null = null
   private dashboardConfigPromise: Promise<DashboardConfig> | null = null
   private dashboardConfigError: Error | null = null
@@ -240,12 +226,9 @@ export class ZKPassport {
       })
     logger.debug("Verification complete, verified:", verified)
     const hasFailedProofs = this.topicToFailedProofCount[topic] > 0
-    // `verified` only covers the proofs that arrived. If any failed to generate
-    // on the mobile device, the overall result is invalid.
     const finalVerified = hasFailedProofs ? false : verified
-    // Browser-only callers (no domain passed) don't submit — the dashboard
-    // has no way to authenticate them. devMode proofs are mock proofs and
-    // would pollute real-domain stats.
+    // Browser-only callers (no explicit domain) can't be authenticated; devMode submits would
+    // pollute real-domain stats.
     const devMode = this.topicToLocalConfig[topic]?.devMode === true
     if (finalVerified && this.domainProvided && !this.disableProofStorage && !devMode) {
       void submitProof({
@@ -477,21 +460,11 @@ export class ZKPassport {
         }
         const policy = this.findPolicy(this.dashboardConfig, id)
         this.topicToConfig[topic] = policy.query
-        // Merge policy values into the request. Caller-supplied request() args
-        // win per field; the policy fills in whatever the caller omitted.
-        // name/logo were already resolved against the dashboard config in
-        // request() and aren't carried on the policy itself.
+        // Policy locks purpose and scope — caller overrides via request() are ignored.
         const svc = this.topicToService[topic]
         if (svc) {
-          svc.purpose = svc.purpose || policy.purpose || ""
-          svc.scope = svc.scope || policyScope(policy)
-        }
-        const caller = this.topicToCallerArgs[topic] ?? {}
-        const local = this.topicToLocalConfig[topic]
-        if (local) {
-          local.validity = caller.validity || policy.validity || DEFAULT_VALIDITY
-          local.mode = caller.mode || policy.mode || "fast"
-          local.devMode = caller.devMode ?? policy.devMode ?? false
+          svc.purpose = policy.purpose || DEFAULT_PURPOSE
+          svc.scope = policyScope(policy)
         }
         this.topicToPolicy[topic] = { id: policy.id, version: policy.version }
         return this.getZkPassportRequest(topic)
@@ -505,33 +478,10 @@ export class ZKPassport {
           return { query }
         }
 
-        const svc = this.topicToService[topic]
-        if (!svc.name || !svc.logo || !svc.purpose) {
-          if (this.topicToPolicy[topic]) {
-            throw new Error(
-              `Policy '${this.topicToPolicy[topic].id}' is missing required service branding (name/logo/purpose) and no per-request override was provided.`,
-            )
-          }
-          throw new Error(
-            "request() requires `name`, `logo`, and `purpose` unless `.policy('<id>')` is called on the builder.",
-          )
-        }
-
         const localConfig = this.topicToLocalConfig[topic]
         const query = this.topicToConfig[topic]
         const hasStrictFacematch = !!query.facematch && query.facematch?.mode === "strict"
 
-        // If nullifier type wasn't explicitly set, default to SALTED only for strict facematch
-        // if (localConfig.uniqueIdentifierType === undefined) {
-        //   if (hasStrictFacematch) {
-        //     localConfig.uniqueIdentifierType = NullifierType.SALTED
-        //     if (!localConfig.oprfKeyId) {
-        //       localConfig.oprfKeyId = OPRF_DEFAULT_KEY_ID
-        //     }
-        //   }
-        // }
-
-        // Validate: SALTED requires strict facematch
         if (localConfig.uniqueIdentifierType === NullifierType.SALTED && !hasStrictFacematch) {
           throw new Error(
             "Salted nullifier requires strict facematch. Add .facematch('strict') to your query or remove the salted nullifier option.",
@@ -542,7 +492,7 @@ export class ZKPassport {
           url: this._getUrl(topic),
           query: this.topicToConfig[topic],
           requestId: topic,
-          policy: this.topicToPolicy[topic],
+          policy: this.topicToPolicy[topic]?.id,
           onRequestReceived: (callback: () => void) =>
             this.onRequestReceivedCallbacks[topic].push(callback),
           onGeneratingProof: (callback: () => void) =>
@@ -570,7 +520,6 @@ export class ZKPassport {
     }
   }
 
-  /** Returns the cached dashboard config, fetching it on first call. */
   private async getDashboardConfig(): Promise<DashboardConfig> {
     if (this.dashboardConfig) return this.dashboardConfig
     if (!this.dashboardConfigPromise) {
@@ -587,12 +536,11 @@ export class ZKPassport {
     return this.dashboardConfigPromise
   }
 
-  /** HTTP fetch + parse + shape-validate of the per-domain dashboard config. */
   private async fetchDashboardConfig(): Promise<DashboardConfig> {
     const url = `${DASHBOARD_API_BASE_URL}/public/app?domain=${encodeURIComponent(this.domain)}`
     let response: Response
     try {
-      response = await fetch(url)
+      response = await fetch(url, { signal: AbortSignal.timeout(10000) })
     } catch (e) {
       throw new Error(
         `Failed to fetch dashboard config for domain '${this.domain}': ${(e as Error).message}`,
@@ -615,7 +563,6 @@ export class ZKPassport {
     return config
   }
 
-  /** Find and shape-validate a policy in an already-fetched config. */
   private findPolicy(config: DashboardConfig, policyId: string): Policy {
     const policy = config.policies.find((p) => p.id === policyId)
     if (!policy) {
@@ -636,7 +583,6 @@ export class ZKPassport {
     return policy
   }
 
-  /** Preconditions for applying a policy via the `.policy()` builder method. */
   private assertCanApplyPolicy(topic: string, id: string): void {
     if (typeof id !== "string" || id.length === 0) {
       throw new Error(".policy() requires a non-empty string id.")
@@ -652,16 +598,15 @@ export class ZKPassport {
   }
 
   /**
-   * @notice Create a new request. To apply a policy, chain `.policy('<id>')`
-   * on the returned builder. Caller-supplied fields here override the policy's
-   * stored values; fields the caller omits fall back to the policy.
-   * @param name Your service name. Required at `.done()` time; falls back to the dashboard branding (`app.name`) if omitted.
-   * @param logo The logo of your service. Required at `.done()` time; falls back to the dashboard branding (`app.logoUrl`) if omitted.
-   * @param purpose To explain what you want to do with the user's data. Required at `.done()` time; with `.policy()`, falls back to the policy's `purpose`.
-   * @param scope Scope this request to a specific use case. With `.policy()`, defaults to `<policyId>@v<version>`.
+   * @notice Create a new request. To apply a policy, chain `.policy('<id>')` on
+   * the returned builder; a policy locks query, purpose and scope.
+   * @param name Your service name. Defaults to the dashboard branding, then the domain.
+   * @param logo Your service logo. Defaults to the dashboard branding.
+   * @param purpose Explanation shown to the user. Defaults to a generic message. Locked by `.policy()`.
+   * @param scope Use-case scope (drives the nullifier). Defaults to the domain. Locked by `.policy()` (to `<id>:<version>`).
    * @param projectID The project ID of your service
    * @param validity How many seconds ago the proof checking the expiry date of the ID should have been generated
-   * @param mode The proof mode (e.g. "fast" / "compressed"). With `.policy()`, defaults to the policy's `mode`.
+   * @param mode The proof mode (e.g. "fast" / "compressed").
    * @param devMode Whether to enable dev mode. This will allow you to verify mock proofs (i.e. from ZKR)
    * @returns The query builder object.
    */
@@ -700,17 +645,11 @@ export class ZKPassport {
       throw new Error("You cannot override the topic with 'offline-query'")
     }
 
-    // Best-effort fetch of the per-domain config so name/logo can default to
-    // the dashboard branding and so a later `.policy('<id>')` can read the
-    // cached config. Self-serve callers (no `.policy()` later) aren't blocked
-    // by a dashboard outage; `.policy()` itself throws if the cache is empty.
     let config: DashboardConfig | undefined
     try {
       config = await this.getDashboardConfig()
       this.dashboardConfigError = null
     } catch (e) {
-      // Stored so `.policy()` can re-throw it if the caller asks for a policy.
-      // Self-serve callers (no `.policy()`) aren't blocked by a failed fetch.
       this.dashboardConfigError = e as Error
     }
 
@@ -723,19 +662,15 @@ export class ZKPassport {
     const topic = bridge.connection.getBridgeId()
 
     this.topicToConfig[topic] = {}
-    // `||` not `??`: empty caller values fall through to dashboard defaults.
-    // purpose/scope have no domain-level defaults — they come from a policy
-    // (resolved later in `.policy()`) or stay caller-only.
     this.topicToService[topic] = {
-      name: name || config?.app?.name || "",
+      name: name || config?.app?.name || this.domain,
       logo: logo || config?.app?.logoUrl || "",
-      purpose: purpose || "",
-      scope,
+      purpose: purpose || DEFAULT_PURPOSE,
+      scope: scope || this.domain,
       projectID,
       cloudProverUrl,
       bridgeUrl,
     }
-    this.topicToCallerArgs[topic] = { validity, mode, devMode }
     this.topicToProofs[topic] = []
     this.topicToLocalConfig[topic] = {
       validity: validity || DEFAULT_VALIDITY,
@@ -1043,7 +978,6 @@ export class ZKPassport {
     delete this.topicToFailedProofCount[requestId]
     delete this.topicToResults[requestId]
     delete this.topicToPolicy[requestId]
-    delete this.topicToCallerArgs[requestId]
     this.onRequestReceivedCallbacks[requestId] = []
     this.onGeneratingProofCallbacks[requestId] = []
     this.onBridgeConnectCallbacks[requestId] = []

--- a/packages/zkpassport-sdk/src/index.ts
+++ b/packages/zkpassport-sdk/src/index.ts
@@ -234,8 +234,8 @@ export class ZKPassport {
       void submitProof({
         domain: this.domain,
         proofs: this.topicToProofs[topic],
+        query: this.topicToConfig[topic],
         queryResult: result,
-        uniqueIdentifier,
         scope: this.topicToService[topic]?.scope,
       })
     }

--- a/packages/zkpassport-sdk/src/types.ts
+++ b/packages/zkpassport-sdk/src/types.ts
@@ -73,19 +73,12 @@ export type Policy = {
   version: number
   name: string
   purpose: string
-  applicationId: string | null
+  projectId: string | null
   query: Query
 }
 
-/**
- * The per-domain configuration returned by the dashboard's `/public/app`
- * endpoint. Includes the verified app and the policies that may run against
- * this domain (org-wide policies plus any locked to this app). `policies` may
- * be empty — that's a valid response for a registered domain with no policies
- * yet.
- */
 export type DashboardConfig = {
-  app: {
+  project: {
     name: string
     domain: string
     logoUrl: string | null

--- a/packages/zkpassport-sdk/src/types.ts
+++ b/packages/zkpassport-sdk/src/types.ts
@@ -10,7 +10,6 @@ import {
   DisclosableIDCredential,
   FacematchMode,
   ProofResult,
-  ProofMode,
   SupportedChain,
   Query,
 } from "@zkpassport/utils"
@@ -69,27 +68,11 @@ export type SolidityVerifierParameters = {
   serviceConfig: SolidityServiceConfig
 }
 
-/**
- * An immutable, versioned policy belonging to an organization (optionally
- * locked to one application). The SDK looks one up by `id` from the per-domain
- * `DashboardConfig` and uses its `query` to populate the request. The scope of
- * a policy-driven request defaults to `<id>@v<version>` so proofs from
- * different versions stay filterable apart (overridable only by an explicit
- * `scope` passed to `request()`).
- *
- * Mirrors the row returned by the dashboard's `/public/app` endpoint.
- */
 export type Policy = {
   id: string
   version: number
   name: string
-  /** Per-policy default purpose, overridable per-request. Empty string when unset. */
   purpose: string
-  /** Default validity window for proofs in seconds. */
-  validity: number | null
-  mode: ProofMode
-  devMode: boolean
-  /** NULL = reusable across the org, set = locked to that app. */
   applicationId: string | null
   query: Query
 }
@@ -128,9 +111,9 @@ export type QueryBuilderResult = {
    */
   requestId: string
   /**
-   * The policy used to build the request, if one was provided.
+   * The id of the policy used to build the request, if one was provided.
    */
-  policy?: { id: string; version: number }
+  policy?: string
   /**
    * Called when the user has scanned the QR code or clicked the link to the request.
    *
@@ -302,21 +285,9 @@ export type QueryBuilder<T extends "online" | "offline" = "online"> = {
    */
   facematch: (mode?: FacematchMode) => QueryBuilder
   /**
-   * Applies an immutable policy that was pre-fetched as part of the per-domain
-   * dashboard config during `request()`. The returned builder has its query locked:
-   * any subsequent `.gte()`, `.disclose()`, etc. will throw.
-   *
-   * Intended usage is `(await zk.request({...})).policy('<id>').done()`. Any
-   * branding (`name`/`logo`/`purpose`/`scope`) or per-request fields
-   * (`validity`/`mode`/`devMode`) passed to `request()` override the policy's
-   * stored values; fields the caller omits fall back to the policy.
-   *
-   * Combining `.policy()` with builder methods like `.gte()`/`.disclose()` in
-   * either order throws.
-   *
-   * Throws synchronously if the dashboard config was not available (the fetch
-   * during `request()` failed).
-   *
+   * Applies an immutable policy fetched from the dashboard. The policy's query,
+   * purpose and scope are locked; combining with builder methods or calling
+   * twice throws.
    * @param id The policy id (e.g. `'pol_xyz'`).
    */
   policy: (id: string) => QueryBuilder<T>

--- a/packages/zkpassport-sdk/tests/proof-submission.test.ts
+++ b/packages/zkpassport-sdk/tests/proof-submission.test.ts
@@ -79,8 +79,9 @@ describe("Proof submission", () => {
     expect(body).toMatchObject({
       domain: "localhost",
       scope: "test-scope",
-      uniqueIdentifier: "uid-1",
+      query: { age: { gte: 18 } },
     })
+    expect(body.uniqueIdentifier).toBeUndefined()
     expect(body.proofs).toHaveLength(1)
     expect(body.proofs[0]).toMatchObject({ proof: "0xdeadbeef", name: "outer_xyz" })
   })

--- a/packages/zkpassport-sdk/tests/query-builder.test.ts
+++ b/packages/zkpassport-sdk/tests/query-builder.test.ts
@@ -562,8 +562,9 @@ describe("Policy-driven requests", () => {
     expect(service.scope).toBe("pol_xyz:3")
   })
 
-  test("policy locks purpose and scope — per-request values are ignored", async () => {
+  test("policy locks scope but caller's purpose still wins", async () => {
     // scope drives the nullifier, so callers can't change it once a policy is bound.
+    // purpose is user-facing copy, so callers can override the policy default.
     const queryBuilder = (
       await zkPassport.request({
         purpose: "Caller-supplied purpose",
@@ -574,7 +575,7 @@ describe("Policy-driven requests", () => {
 
     const servicePart = result.url.split("s=")[1].split("&")[0]
     const service = JSON.parse(Buffer.from(servicePart, "base64").toString())
-    expect(service.purpose).toBe("Policy purpose")
+    expect(service.purpose).toBe("Caller-supplied purpose")
     expect(service.scope).toBe("pol_xyz:3")
   })
 

--- a/packages/zkpassport-sdk/tests/query-builder.test.ts
+++ b/packages/zkpassport-sdk/tests/query-builder.test.ts
@@ -464,7 +464,7 @@ describe("Policy-driven requests", () => {
   let fetchCount: number
 
   const sampleConfig = {
-    app: {
+    project: {
       name: "Dashboard Brand",
       domain: "localhost",
       logoUrl: "https://dashboard.example/logo.png",
@@ -476,7 +476,7 @@ describe("Policy-driven requests", () => {
         version: 3,
         name: "Age + nationality",
         purpose: "Policy purpose",
-        applicationId: null,
+        projectId: null,
         query: {
           age: { gte: 18 },
           firstname: { disclose: true },
@@ -488,7 +488,7 @@ describe("Policy-driven requests", () => {
         version: 1,
         name: "Adults only",
         purpose: "",
-        applicationId: null,
+        projectId: null,
         query: { age: { gte: 21 } },
       },
     ],
@@ -523,7 +523,7 @@ describe("Policy-driven requests", () => {
     const queryBuilder = (await zkPassport.request({})).policy("pol_xyz")
     const result = queryBuilder.done()
 
-    expect(lastFetchUrl).toBe("https://dashboard-api.zkpassport.id/public/app?domain=localhost")
+    expect(lastFetchUrl).toBe("https://dashboard-api.zkpassport.id/public/project?domain=localhost")
     expect(result.policy).toBe("pol_xyz")
     expect(result.query).toEqual(sampleConfig.policies[0].query)
 
@@ -631,7 +631,7 @@ describe("Policy-driven requests", () => {
   test(".policy() rejects a policy with an invalid version", async () => {
     for (const version of [0, -1]) {
       mockFetchReturning({
-        app: {
+        project: {
           name: "Brand",
           domain: "localhost",
           logoUrl: "https://e/l.png",
@@ -643,7 +643,7 @@ describe("Policy-driven requests", () => {
             version,
             name: "x",
             purpose: "",
-            applicationId: null,
+            projectId: null,
             query: { age: { gte: 18 } },
           },
         ],
@@ -656,14 +656,14 @@ describe("Policy-driven requests", () => {
 
   test("policy with empty branding falls back to defaults (domain / generic purpose)", async () => {
     mockFetchReturning({
-      app: { name: "", domain: "localhost", logoUrl: null, allowedOrigins: [] },
+      project: { name: "", domain: "localhost", logoUrl: null, allowedOrigins: [] },
       policies: [
         {
           id: "pol_blank",
           version: 1,
           name: "blank",
           purpose: "",
-          applicationId: null,
+          projectId: null,
           query: { age: { gte: 18 } },
         },
       ],

--- a/packages/zkpassport-sdk/tests/query-builder.test.ts
+++ b/packages/zkpassport-sdk/tests/query-builder.test.ts
@@ -7,12 +7,9 @@ describe("Query Builder", () => {
   let originalFetch: typeof globalThis.fetch
 
   beforeEach(async () => {
-    // Clear any previous mock states
     MockWebSocket.clearHub()
 
-    // request() now always fetches the dashboard config. Stub it so these
-    // tests don't depend on the network — self-serve mode swallows failures,
-    // but a real call still leaks during every test run.
+    // request() fetches the dashboard config best-effort; stub so tests stay offline.
     originalFetch = globalThis.fetch
     globalThis.fetch = (async () =>
       new Response("{}", {
@@ -148,6 +145,7 @@ describe("Query Builder", () => {
       name: "Test App",
       logo: "https://test.com/logo.png",
       purpose: "Testing query builder",
+      scope: "localhost",
     })
   })
 
@@ -465,7 +463,6 @@ describe("Policy-driven requests", () => {
   let lastFetchUrl: string | undefined
   let fetchCount: number
 
-  // Mirrors the real `/public/app?domain=...` response shape.
   const sampleConfig = {
     app: {
       name: "Dashboard Brand",
@@ -479,9 +476,6 @@ describe("Policy-driven requests", () => {
         version: 3,
         name: "Age + nationality",
         purpose: "Policy purpose",
-        validitySeconds: null,
-        proofMode: "fast",
-        devMode: false,
         applicationId: null,
         query: {
           age: { gte: 18 },
@@ -494,9 +488,6 @@ describe("Policy-driven requests", () => {
         version: 1,
         name: "Adults only",
         purpose: "",
-        validitySeconds: null,
-        proofMode: "fast",
-        devMode: false,
         applicationId: null,
         query: { age: { gte: 21 } },
       },
@@ -533,7 +524,7 @@ describe("Policy-driven requests", () => {
     const result = queryBuilder.done()
 
     expect(lastFetchUrl).toBe("https://dashboard-api.zkpassport.id/public/app?domain=localhost")
-    expect(result.policy).toEqual({ id: "pol_xyz", version: 3 })
+    expect(result.policy).toBe("pol_xyz")
     expect(result.query).toEqual(sampleConfig.policies[0].query)
 
     const servicePart = result.url.split("s=")[1].split("&")[0]
@@ -542,7 +533,7 @@ describe("Policy-driven requests", () => {
       name: "Dashboard Brand",
       logo: "https://dashboard.example/logo.png",
       purpose: "Policy purpose",
-      scope: "pol_xyz@v3",
+      scope: "pol_xyz:3",
     })
   })
 
@@ -566,29 +557,37 @@ describe("Policy-driven requests", () => {
     const service = JSON.parse(Buffer.from(servicePart, "base64").toString())
     expect(service.name).toBe("White Label")
     expect(service.logo).toBe("https://white.example/logo.png")
-    // unspecified fields fall back to dashboard / policy defaults
+    // purpose/scope are locked by the policy
     expect(service.purpose).toBe("Policy purpose")
-    expect(service.scope).toBe("pol_xyz@v3")
+    expect(service.scope).toBe("pol_xyz:3")
   })
 
-  test("per-request purpose/scope override policy defaults", async () => {
+  test("policy locks purpose and scope — per-request values are ignored", async () => {
+    // scope drives the nullifier, so callers can't change it once a policy is bound.
     const queryBuilder = (
       await zkPassport.request({
-        purpose: "Custom purpose",
-        scope: "custom-scope",
+        purpose: "Caller-supplied purpose",
+        scope: "caller-supplied-scope",
       })
     ).policy("pol_xyz")
     const result = queryBuilder.done()
 
     const servicePart = result.url.split("s=")[1].split("&")[0]
     const service = JSON.parse(Buffer.from(servicePart, "base64").toString())
-    expect(service.purpose).toBe("Custom purpose")
-    expect(service.scope).toBe("custom-scope")
+    expect(service.purpose).toBe("Policy purpose")
+    expect(service.scope).toBe("pol_xyz:3")
   })
 
-  test("done() throws if neither a policy nor name/logo/purpose are provided", async () => {
+  test("self-serve callers get sensible defaults when no fields are supplied", async () => {
     const queryBuilder = await zkPassport.request({})
-    expect(() => queryBuilder.done()).toThrow(/request\(\) requires .name., .logo., and .purpose./)
+    const result = queryBuilder.done()
+    const servicePart = result.url.split("s=")[1].split("&")[0]
+    const service = JSON.parse(Buffer.from(servicePart, "base64").toString())
+    // name/logo come from the dashboard config when registered; purpose/scope fall to defaults.
+    expect(service.name).toBe("Dashboard Brand")
+    expect(service.logo).toBe("https://dashboard.example/logo.png")
+    expect(service.purpose).toBe("Verify identity privately")
+    expect(service.scope).toBe("localhost")
   })
 
   test(".policy() throws a clear 'domain not registered' error on 404", async () => {
@@ -644,9 +643,6 @@ describe("Policy-driven requests", () => {
             version,
             name: "x",
             purpose: "",
-            validitySeconds: null,
-            proofMode: "fast",
-            devMode: false,
             applicationId: null,
             query: { age: { gte: 18 } },
           },
@@ -658,7 +654,7 @@ describe("Policy-driven requests", () => {
     }
   })
 
-  test("done() throws if a policy returns empty branding and no per-request override is given", async () => {
+  test("policy with empty branding falls back to defaults (domain / generic purpose)", async () => {
     mockFetchReturning({
       app: { name: "", domain: "localhost", logoUrl: null, allowedOrigins: [] },
       policies: [
@@ -667,9 +663,6 @@ describe("Policy-driven requests", () => {
           version: 1,
           name: "blank",
           purpose: "",
-          validitySeconds: null,
-          proofMode: "fast",
-          devMode: false,
           applicationId: null,
           query: { age: { gte: 18 } },
         },
@@ -677,7 +670,13 @@ describe("Policy-driven requests", () => {
     })
 
     const queryBuilder = (await zkPassport.request({})).policy("pol_blank")
-    expect(() => queryBuilder.done()).toThrow(/missing required service branding/i)
+    const result = queryBuilder.done()
+    const servicePart = result.url.split("s=")[1].split("&")[0]
+    const service = JSON.parse(Buffer.from(servicePart, "base64").toString())
+    expect(service.name).toBe("localhost")
+    expect(service.logo).toBe("")
+    expect(service.purpose).toBe("Verify identity privately")
+    expect(service.scope).toBe("pol_blank:1")
   })
 
   test("self-serve callers benefit from dashboard branding when the domain is registered", async () => {
@@ -716,6 +715,6 @@ describe("Policy-driven requests", () => {
     mockFetchReturning(sampleConfig)
     const builder = await zkPassport.request({})
     const result = builder.policy("pol_xyz").done()
-    expect(result.policy).toEqual({ id: "pol_xyz", version: 3 })
+    expect(result.policy).toBe("pol_xyz")
   })
 })


### PR DESCRIPTION
## Summary

Addresses review comments on #201.

- `Policy` no longer carries `validity`/`mode`/`devMode` — those are request-time knobs; the whole `topicToCallerArgs` merge apparatus is gone.
- `.policy()` now **locks** `purpose` and `scope`. Caller-supplied values are ignored when a policy is bound (preserves nullifier integrity).
- `request({})` works with no fields: defaults to `name=<domain>`, `purpose="Verify identity privately"`, `scope=<domain>`, `logo=""`. `done()` no longer throws on missing branding.
- Scope format `${id}:${version}` (was `${id}@v${version}`).
- `QueryBuilderResult.policy` is now `string | undefined` (just the id).
- Dashboard fetch has a 10s `AbortSignal.timeout` so Node callers can't hang.
- `dashboard-api.ts` switched from `noLogger` to `customLogger` so submission failures actually surface.
- JSDoc/inline comments trimmed per "remove comments" feedback; dead salted-nullifier block removed.

## Push-back worth flagging

Dropping structured `{id, version}` from the result means callers who want to surface "policy v3" in a UI must parse it out of the scope string. The version is recoverable, but slightly less ergonomic — happy to bring `{id, version}` back if that matters.

## Test plan

- [x] `bun test` — 178/178 pass
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run check` — clean (one pre-existing `ZERO_BYTES32` warning in `solidity-verifier.ts`, unrelated)