### PR TITLE
fix(utils): disclose name from the MRZ instead of DG11

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -136,7 +136,7 @@
     },
     "packages/zkpassport-utils": {
       "name": "@zkpassport/utils",
-      "version": "0.36.1",
+      "version": "0.36.2",
       "dependencies": {
         "@lapo/asn1js": "^2.0.4",
         "@noble/ciphers": "^1.0.0",

--- a/packages/zkpassport-sdk/tests/public-input-checker.test.ts
+++ b/packages/zkpassport-sdk/tests/public-input-checker.test.ts
@@ -12,6 +12,7 @@ import {
   getServiceScopeHash,
   getScopeHash,
   getAgeParameterCommitment,
+  getDisclosedBytesFromMrzAndMask,
 } from "@zkpassport/utils"
 import {
   APPLE_APP_ATTEST_ROOT_KEY_HASH,
@@ -278,6 +279,51 @@ describe("PublicInputChecker - originalQuery validation", () => {
           queryResult,
         )
         expect(hasOriginalQueryError(queryResultErrors.document_type, "eq")).toBe(false)
+      })
+    })
+
+    describe("name sourced from MRZ", () => {
+      // John Miller Smith's MRZ: surname "SMITH" before "<<", given names "JOHN MILLER" after.
+      const johnMRZ =
+        "P<ZKRSMITH<<JOHN<MILLER<<<<<<<<<<<<<<<<<<<<<ZP1111111_ZKR951112_M350101_<<<<<<<<<<<<<<<<"
+      // Reveal the firstname + lastname region (SMITH<<JOHN) exactly as the proof would.
+      const nameMask = new Array(90).fill(0)
+      nameMask.fill(1, 5, 16)
+      const proof = makeDiscloseProof(getDisclosedBytesFromMrzAndMask(johnMRZ, nameMask))
+      const originalQuery: Query = {
+        firstname: { disclose: true },
+        lastname: { disclose: true },
+      }
+
+      // Reproduces the bug: the app sourced the lastname from DG11, where the whole name landed in
+      // the lastname field. The verifier parses "SMITH" from the MRZ proof, so they mismatch.
+      test("fails when lastname is the DG11 full name instead of the MRZ surname", () => {
+        const queryResult: QueryResult = {
+          firstname: { disclose: { result: "John" } },
+          lastname: { disclose: { result: "John Miller Smith" } },
+        }
+        const { queryResultErrors } = PublicInputChecker.checkDiscloseBytesPublicInputs(
+          proof,
+          originalQuery,
+          queryResult,
+        )
+        expect(queryResultErrors.lastname?.disclose).toBeDefined()
+      })
+
+      // Confirms the fix: when the app sources the name from the MRZ (firstName "JOHN",
+      // lastName "SMITH"), both name fields match the proof and verification passes.
+      test("passes when firstname/lastname are sourced from the MRZ", () => {
+        const queryResult: QueryResult = {
+          firstname: { disclose: { result: "John" } },
+          lastname: { disclose: { result: "Smith" } },
+        }
+        const { queryResultErrors } = PublicInputChecker.checkDiscloseBytesPublicInputs(
+          proof,
+          originalQuery,
+          queryResult,
+        )
+        expect(queryResultErrors.firstname?.disclose).toBeUndefined()
+        expect(queryResultErrors.lastname?.disclose).toBeUndefined()
       })
     })
   })

--- a/packages/zkpassport-utils/package.json
+++ b/packages/zkpassport-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkpassport/utils",
-  "version": "0.36.1",
+  "version": "0.36.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/zkpassport/zkpassport-packages",

--- a/packages/zkpassport-utils/src/circuit-matcher.ts
+++ b/packages/zkpassport-utils/src/circuit-matcher.ts
@@ -16,7 +16,7 @@ import {
   normalizeDg2Hash,
   SECONDS_BETWEEN_1900_AND_1970,
 } from "./circuits"
-import { parseDate } from "./circuits/disclose"
+import { DisclosedData, getDisclosedBytesFromMrzAndMask, parseDate } from "./circuits/disclose"
 import type { DigestAlgorithm } from "./cms/types"
 import {
   getBitSizeFromCurve,
@@ -814,6 +814,25 @@ export async function getDiscloseCircuitInputs(
     privateNullifier.toBigInt(),
   )
 
+  const discloseMask = getDiscloseMask(passport, query)
+  return {
+    current_date: currentDateTimestamp,
+    ...(await getSaltedValuesForDisclosureCircuit(passport, idData, privateNullifier, salts)),
+    disclose_mask: discloseMask,
+    comm_in: commIn.toHex(),
+    service_scope: `0x${service_scope.toString(16)}`,
+    service_subscope: `0x${service_subscope.toString(16)}`,
+    nullifier_secret: `0x${nullifierSecret.toString(16)}`,
+    oprf_proof: oprfProof,
+  }
+}
+
+/**
+ * Build the 90-byte disclosure mask over the MRZ for the fields a query reveals (via `disclose`
+ * or `eq`). This is the mask committed to by the disclose proof. Shared by getDiscloseCircuitInputs
+ * (to build the proof) and getMrzDisclosedNames (to reconstruct the disclosed values).
+ */
+export function getDiscloseMask(passport: PassportViewModel, query: Query): number[] {
   const discloseMask = Array(90).fill(0)
   const fieldsToDisclose: { [key in IDCredential]: boolean } = {} as any
   for (const field in query) {
@@ -875,16 +894,27 @@ export async function getDiscloseCircuitInputs(
       }
     }
   }
-  return {
-    current_date: currentDateTimestamp,
-    ...(await getSaltedValuesForDisclosureCircuit(passport, idData, privateNullifier, salts)),
-    disclose_mask: discloseMask,
-    comm_in: commIn.toHex(),
-    service_scope: `0x${service_scope.toString(16)}`,
-    service_subscope: `0x${service_subscope.toString(16)}`,
-    nullifier_secret: `0x${nullifierSecret.toString(16)}`,
-    oprf_proof: oprfProof,
-  }
+  return discloseMask
+}
+
+/**
+ * Reconstruct the disclosed name fields from the MRZ exactly as the verifier does: apply the
+ * proof's disclosure mask to the MRZ and parse the result with DisclosedData.fromDisclosedBytes.
+ * Because it reuses getDiscloseMask, the returned values are byte-for-byte what PublicInputChecker
+ * reconstructs from the proof — independent of the DG11 display name.
+ */
+export function getMrzDisclosedNames(
+  passport: PassportViewModel,
+  query: Query,
+): { firstName: string; lastName: string; fullName: string } {
+  // Same heuristic the name-range getters use to pick the MRZ layout
+  const isIDCard = passport.mrz.length === 90
+  const disclosedBytes = getDisclosedBytesFromMrzAndMask(
+    passport.mrz,
+    getDiscloseMask(passport, query),
+  )
+  const data = DisclosedData.fromDisclosedBytes(disclosedBytes, isIDCard ? "id_card" : "passport")
+  return { firstName: data.firstName, lastName: data.lastName, fullName: data.name }
 }
 
 export function calculateAge(passport: PassportViewModel, now?: Date): number {

--- a/packages/zkpassport-utils/tests/circuit-matcher.test.ts
+++ b/packages/zkpassport-utils/tests/circuit-matcher.test.ts
@@ -12,6 +12,7 @@ import {
   getIntegrityCheckCircuitInputs,
   getIssuingCountryExclusionCircuitInputs,
   getIssuingCountryInclusionCircuitInputs,
+  getMrzDisclosedNames,
   getNationalityExclusionCircuitInputs,
   getNationalityInclusionCircuitInputs,
   isCscaSupported,
@@ -42,6 +43,8 @@ import {
   SECONDS_BETWEEN_1900_AND_1970,
   HASH_ALGORITHM_SHA256,
   OPRF_ZERO_PROOF,
+  DisclosedData,
+  getDisclosedBytesFromMrzAndMask,
 } from "../src"
 import { DSC } from "../src/passport/dsc"
 import { AsnParser } from "@peculiar/asn1-schema"
@@ -440,6 +443,39 @@ describe("Circuit Matcher - RSA", () => {
       nullifier_secret: EXPECTED_NULLIFIER_SECRET,
       oprf_proof: OPRF_ZERO_PROOF,
     })
+  })
+
+  it("getMrzDisclosedNames matches the verifier's parsing of the real proof mask", async () => {
+    const query: Query = {
+      firstname: { disclose: true },
+      lastname: { disclose: true },
+      birthdate: { disclose: true },
+      nationality: { disclose: true },
+      issuing_country: { disclose: true },
+    }
+    // Build the actual disclose proof inputs, then reconstruct the name exactly as
+    // PublicInputChecker does: apply the real disclose_mask to the MRZ and parse with
+    // DisclosedData.fromDisclosedBytes. The helper must produce the same name values.
+    const inputs = await getDiscloseCircuitInputs(
+      PASSPORTS.john,
+      query,
+      { dg1Salt: SALT, expiryDateSalt: SALT, dg2HashSalt: SALT, privateNullifierSalt: SALT },
+      NULLIFIER_SECRET,
+      SERVICE_SCOPE,
+      SERVICE_SUBSCOPE,
+      CURRENT_DATE,
+    )
+    const disclosedBytes = getDisclosedBytesFromMrzAndMask(
+      PASSPORTS.john.mrz,
+      inputs!.disclose_mask,
+    )
+    const fromProof = DisclosedData.fromDisclosedBytes(disclosedBytes, "passport")
+    const fromHelper = getMrzDisclosedNames(PASSPORTS.john, query)
+
+    expect(fromHelper.firstName).toEqual(fromProof.firstName)
+    expect(fromHelper.lastName).toEqual(fromProof.lastName)
+    expect(fromHelper.firstName).toBe("JOHN")
+    expect(fromHelper.lastName).toBe("SMITH")
   })
 
   it("should calculate the correct age from passport", () => {

--- a/packages/zkpassport-utils/tests/mrz-disclosed-names.test.ts
+++ b/packages/zkpassport-utils/tests/mrz-disclosed-names.test.ts
@@ -1,4 +1,5 @@
 import { getMrzDisclosedNames } from "../src/circuit-matcher"
+import type { PassportViewModel, Query } from "../src/types"
 import { PASSPORTS } from "./fixtures/passports"
 
 // John Miller Smith's MRZ encodes the surname before "<<" and the given names after it:
@@ -21,5 +22,24 @@ describe("getMrzDisclosedNames", () => {
   it("firstname is the first given name only (accepted under-disclosure of the firstname mask)", () => {
     const result = getMrzDisclosedNames(PASSPORTS.john, { firstname: { disclose: true } })
     expect(result.firstName).toBe("JOHN")
+  })
+
+  it("widens firstname to all given names when fullname is co-disclosed", () => {
+    // Disclosing fullname reveals the whole name field, so firstname picks up every given name.
+    // The verifier derives both from the same widened mask, so they still agree.
+    const query: Query = { firstname: { disclose: true }, fullname: { disclose: true } }
+    const result = getMrzDisclosedNames(PASSPORTS.john, query)
+    expect(result.firstName).toBe("JOHN MILLER")
+    expect(result.fullName).toBe("JOHN MILLER SMITH")
+  })
+
+  it("reads the name from the id-card (TD1) offsets when the MRZ is 90 chars", () => {
+    // TD1: 3 lines of 30 chars; the name lives in the third line (bytes 60-90). Only `mrz` is read.
+    const idCardMRZ = "I".padEnd(60, "<") + "SMITH<<JOHN<MILLER".padEnd(30, "<")
+    const idCard = { mrz: idCardMRZ } as PassportViewModel
+    expect(getMrzDisclosedNames(idCard, { fullname: { disclose: true } }).fullName).toBe(
+      "JOHN MILLER SMITH",
+    )
+    expect(getMrzDisclosedNames(idCard, { lastname: { disclose: true } }).lastName).toBe("SMITH")
   })
 })

--- a/packages/zkpassport-utils/tests/mrz-disclosed-names.test.ts
+++ b/packages/zkpassport-utils/tests/mrz-disclosed-names.test.ts
@@ -1,0 +1,25 @@
+import { getMrzDisclosedNames } from "../src/circuit-matcher"
+import { PASSPORTS } from "./fixtures/passports"
+
+// John Miller Smith's MRZ encodes the surname before "<<" and the given names after it:
+//   P<ZKRSMITH<<JOHN<MILLER<<<...
+// so the MRZ truth is: surname "SMITH", given names "JOHN MILLER".
+// The fixture's DG11-style fields are deliberately different (firstName "John" / lastName "Smith"
+// / fullName "John Miller Smith"); the helper must read only the MRZ, so its output is the
+// uppercase MRZ form — which is what makes these assertions also prove DG11 is not consulted.
+describe("getMrzDisclosedNames", () => {
+  it("fullname is all given names plus the surname", () => {
+    const result = getMrzDisclosedNames(PASSPORTS.john, { fullname: { disclose: true } })
+    expect(result.fullName).toBe("JOHN MILLER SMITH")
+  })
+
+  it("lastname is the surname only (the field Caleb's DG11 polluted with the full name)", () => {
+    const result = getMrzDisclosedNames(PASSPORTS.john, { lastname: { disclose: true } })
+    expect(result.lastName).toBe("SMITH")
+  })
+
+  it("firstname is the first given name only (accepted under-disclosure of the firstname mask)", () => {
+    const result = getMrzDisclosedNames(PASSPORTS.john, { firstname: { disclose: true } })
+    expect(result.firstName).toBe("JOHN")
+  })
+})


### PR DESCRIPTION
## What

When a name is disclosed, the disclosed first name / last name / full name now come from the **MRZ** — the machine-readable strip that the proof actually attests to — instead of the document's separate display field (DG11).

## Why

The two sources can disagree (different surname/given-name split, accented characters, ordering, truncation). When they did, the name in the result didn't match what the proof attested, and **verification failed**. This was reported on a real passport where disclosing the last name failed.

Because the disclosed name is now taken from the same data the proof commits to, it always matches — for the first name, last name and full name alike.

## Scope

- A small helper in `@zkpassport/utils` that derives the name the same way the verifier reads it.
- Tests covering each name field plus a round-trip against a real proof.
- **No changes to the verifier or the circuits.**

The companion mobile-app change (which actually uses this helper) is in a separate PR and depends on the published `@zkpassport/utils` version bumped here.