### PR TITLE
chore(ui): Log SDK errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Need history to compare versions against the base branch
 
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
@@ -84,6 +86,9 @@ jobs:
 
       - name: Ensure workspace dependencies are synced
         run: bash scripts/sync-workspace-deps.sh check
+
+      - name: Ensure UI is bumped when SDK is bumped
+        run: bash scripts/check-ui-bumped-with-sdk.sh
 
   large-file-check:
     name: Large File Check

--- a/bun.lock
+++ b/bun.lock
@@ -110,7 +110,7 @@
     },
     "packages/zkpassport-ui": {
       "name": "@zkpassport/ui",
-      "version": "0.15.1",
+      "version": "0.15.2",
       "dependencies": {
         "@zkpassport/sdk": "workspace:*",
         "qrcode": "^1.5.4",

--- a/bun.lock
+++ b/bun.lock
@@ -112,19 +112,18 @@
       "name": "@zkpassport/ui",
       "version": "0.15.1",
       "dependencies": {
+        "@zkpassport/sdk": "workspace:*",
         "qrcode": "^1.5.4",
       },
       "devDependencies": {
         "@types/qrcode": "^1.5.5",
         "@types/react": "^18.3.0",
         "@types/react-dom": "^18.3.0",
-        "@zkpassport/sdk": "workspace:*",
         "preact": "^10.22.0",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
       },
       "peerDependencies": {
-        "@zkpassport/sdk": "^0.15.1",
         "react": ">=18",
         "react-dom": ">=18",
         "typescript": "^5.0.0",

--- a/packages/zkpassport-ui/package.json
+++ b/packages/zkpassport-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkpassport/ui",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Drop-in QR verification card for ZKPassport. Vanilla JS by default; React component available at @zkpassport/ui/react.",
   "author": "ZKPassport",
   "license": "Apache-2.0",

--- a/packages/zkpassport-ui/package.json
+++ b/packages/zkpassport-ui/package.json
@@ -62,10 +62,10 @@
     "widget"
   ],
   "dependencies": {
+    "@zkpassport/sdk": "workspace:*",
     "qrcode": "^1.5.4"
   },
   "peerDependencies": {
-    "@zkpassport/sdk": "^0.15.1",
     "react": ">=18",
     "react-dom": ">=18",
     "typescript": "^5.0.0"
@@ -82,7 +82,6 @@
     "@types/qrcode": "^1.5.5",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
-    "@zkpassport/sdk": "workspace:*",
     "preact": "^10.22.0",
     "react": "^18.3.0",
     "react-dom": "^18.3.0"

--- a/packages/zkpassport-ui/src/use-card.ts
+++ b/packages/zkpassport-ui/src/use-card.ts
@@ -72,7 +72,8 @@ export function useCard(options: ZKPassportQRCodeOptions): UseCard {
         if (cancelled) return
         try {
           fn(...args)
-        } catch {
+        } catch (reason) {
+          console.error(reason)
           setState("error")
         }
       }
@@ -84,7 +85,8 @@ export function useCard(options: ZKPassportQRCodeOptions): UseCard {
         let request: QueryBuilderResult
         try {
           request = buildQuery(queryBuilder)
-        } catch {
+        } catch (reason) {
+          console.error(reason)
           setState("error")
           return
         }
@@ -139,19 +141,22 @@ export function useCard(options: ZKPassportQRCodeOptions): UseCard {
             setState("waiting")
             fireReady()
           } else setState("connecting")
-        } catch {
+        } catch (reason) {
+          console.error(reason)
           setState("error")
         }
 
         setUrl(request.url)
         try {
           setQrSvg(renderQrSvg(request.url))
-        } catch {
+        } catch (reason) {
+          console.error(reason)
           setState("error")
         }
       })
-      .catch(() => {
+      .catch((reason) => {
         if (cancelled) return
+        console.error(reason)
         setState("error")
       })
 

--- a/scripts/check-ui-bumped-with-sdk.sh
+++ b/scripts/check-ui-bumped-with-sdk.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Enforce the UI/SDK release coupling policy.
+#
+# @zkpassport/ui bundles @zkpassport/sdk as a regular dependency, so an SDK
+# release that changes behavior must ship a new UI release too — otherwise the
+# published UI keeps pointing at the old SDK range. We do NOT require the two
+# version numbers to be equal; we only require that when the SDK version
+# changes relative to the base branch, the UI version changes as well.
+
+set -e
+
+BASE_REF="${1:-origin/main}"
+
+# Read a package.json version at a given git ref; prints nothing on failure.
+version_at_ref() {
+    local ref="$1" path="$2"
+    git show "$ref:$path" 2>/dev/null \
+        | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{try{process.stdout.write(JSON.parse(d).version)}catch(e){}})"
+}
+
+# Make sure the base ref is available (no-op if already fetched / offline).
+git fetch --quiet origin main 2>/dev/null || true
+
+SDK_NOW=$(node -p "require('./packages/zkpassport-sdk/package.json').version")
+UI_NOW=$(node -p "require('./packages/zkpassport-ui/package.json').version")
+
+SDK_BASE=$(version_at_ref "$BASE_REF" "packages/zkpassport-sdk/package.json")
+UI_BASE=$(version_at_ref "$BASE_REF" "packages/zkpassport-ui/package.json")
+
+if [ -z "$SDK_BASE" ] || [ -z "$UI_BASE" ]; then
+    echo "Could not resolve base versions from '$BASE_REF'; skipping UI/SDK bump check."
+    exit 0
+fi
+
+if [ "$SDK_NOW" != "$SDK_BASE" ] && [ "$UI_NOW" = "$UI_BASE" ]; then
+    echo "ERROR: @zkpassport/sdk was bumped ($SDK_BASE -> $SDK_NOW) but @zkpassport/ui was not (still $UI_NOW)."
+    echo "@zkpassport/ui bundles the SDK, so it must be republished when the SDK changes."
+    echo "Bump packages/zkpassport-ui/package.json version (any bump — it need not match the SDK)."
+    exit 1
+fi
+
+echo "OK: UI/SDK bump policy satisfied (SDK $SDK_BASE -> $SDK_NOW, UI $UI_BASE -> $UI_NOW)."

--- a/scripts/sync-workspace-deps.sh
+++ b/scripts/sync-workspace-deps.sh
@@ -11,12 +11,6 @@ echo "Ensuring workspace dependencies are synced"
 (cd packages/registry-sdk && bun update @zkpassport/utils)
 (cd packages/zkpassport-ui && bun update @zkpassport/sdk)
 
-# Keep @zkpassport/ui's version and @zkpassport/sdk peer range pinned to the
-# SDK's current version. Same versions ⇒ no surprises for downstream installs.
-SDK_VERSION=$(cd packages/zkpassport-sdk && npm pkg get version --workspaces=false | tr -d '"')
-(cd packages/zkpassport-ui && npm pkg set --workspaces=false \
-    "version=$SDK_VERSION" \
-    "peerDependencies.@zkpassport/sdk=^$SDK_VERSION")
 bun install
 
 # Check mode for CI: verify that workspace dependencies are synced


### PR DESCRIPTION
  - @zkpassport/ui now depends on @zkpassport/sdk directly instead of
  as a peer dependency, so consumers no longer need to install the SDK
  themselves.
  - Decoupled UI/SDK version numbers (removed the forced-equality
  mandate) and added a CI check that requires the UI version to be
  bumped whenever the SDK version is bumped.