### PR TITLE
feat(sdk): Include requestId when submitting a proof

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -84,7 +84,7 @@
     },
     "packages/zkpassport-sdk": {
       "name": "@zkpassport/sdk",
-      "version": "0.15.4",
+      "version": "0.15.5",
       "dependencies": {
         "@aztec/bb.js": "4.2.0-aztecnr-rc.2",
         "@noble/ciphers": "^1.2.1",
@@ -110,7 +110,7 @@
     },
     "packages/zkpassport-ui": {
       "name": "@zkpassport/ui",
-      "version": "0.15.7",
+      "version": "0.15.8",
       "dependencies": {
         "@zkpassport/sdk": "workspace:*",
         "qrcode": "^1.5.4",

--- a/packages/zkpassport-sdk/package.json
+++ b/packages/zkpassport-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkpassport/sdk",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "description": "Privacy-preserving identity verification using passports and ID cards",
   "author": "ZKPassport",
   "license": "Apache-2.0",

--- a/packages/zkpassport-sdk/src/constants.ts
+++ b/packages/zkpassport-sdk/src/constants.ts
@@ -1,4 +1,4 @@
-export const VERSION = "0.15.4"
+export const VERSION = "0.15.5"
 export const DEFAULT_VALIDITY = 7 * 24 * 60 * 60 // 7 days
 export const DEFAULT_DATE_VALUE = new Date(0)
 

--- a/packages/zkpassport-sdk/src/dashboard-api.ts
+++ b/packages/zkpassport-sdk/src/dashboard-api.ts
@@ -9,12 +9,14 @@ export async function submitProof({
   query,
   queryResult,
   scope,
+  requestId,
 }: {
   domain: string
   proofs: Array<ProofResult>
   query: Query
   queryResult: QueryResult
   scope: string | undefined
+  requestId: string | undefined
 }) {
   const payload = proofs.map((p) => ({
     proof: p.proof,
@@ -36,6 +38,7 @@ export async function submitProof({
         queryResult,
         scope,
         sdkVersion: VERSION,
+        requestId,
       }),
       signal: AbortSignal.timeout(30000),
     })

--- a/packages/zkpassport-sdk/src/index.ts
+++ b/packages/zkpassport-sdk/src/index.ts
@@ -241,6 +241,7 @@ export class ZKPassport {
         query: this.topicToConfig[topic],
         queryResult: result,
         scope: this.topicToService[topic]?.scope,
+        requestId: this.topicToPublicKey[topic],
       })
     }
     delete this.topicToProofs[topic]

--- a/packages/zkpassport-sdk/src/index.ts
+++ b/packages/zkpassport-sdk/src/index.ts
@@ -241,6 +241,7 @@ export class ZKPassport {
         query: this.topicToConfig[topic],
         queryResult: result,
         scope: this.topicToService[topic]?.scope,
+        // Bridge public key (URL `p=`), NOT the topic — must match the mobile app's /activity requestId.
         requestId: this.topicToPublicKey[topic],
       })
     }

--- a/packages/zkpassport-sdk/src/index.ts
+++ b/packages/zkpassport-sdk/src/index.ts
@@ -241,7 +241,6 @@ export class ZKPassport {
         query: this.topicToConfig[topic],
         queryResult: result,
         scope: this.topicToService[topic]?.scope,
-        // Bridge public key (URL `p=`), NOT the topic — must match the mobile app's /activity requestId.
         requestId: this.topicToPublicKey[topic],
       })
     }

--- a/packages/zkpassport-sdk/tests/proof-submission.test.ts
+++ b/packages/zkpassport-sdk/tests/proof-submission.test.ts
@@ -50,6 +50,7 @@ describe("Proof submission", () => {
     i.topicToConfig[topic] = { age: { gte: 18 } }
     i.topicToLocalConfig[topic] = { validity: 0, devMode: false, oprfKeyId: null }
     i.topicToService[topic] = { name: "n", logo: "l", purpose: "p", scope: "test-scope" }
+    i.topicToPublicKey[topic] = "04deadbeefpubkey"
     i.topicToFailedProofCount[topic] = opts.failedProofs ?? 0
     i.onResultCallbacks[topic] = []
     i.verify = async () => opts.verifyResult
@@ -80,10 +81,25 @@ describe("Proof submission", () => {
       domain: "localhost",
       scope: "test-scope",
       query: { age: { gte: 18 } },
+      // The bridge public key (URL `p=`), not the topic — links the proof to its activity row.
+      requestId: "04deadbeefpubkey",
     })
     expect(body.uniqueIdentifier).toBeUndefined()
     expect(body.proofs).toHaveLength(1)
     expect(body.proofs[0]).toMatchObject({ proof: "0xdeadbeef", name: "outer_xyz" })
+  })
+
+  test("omits requestId when the bridge public key is unavailable", async () => {
+    const zk = new ZKPassport("localhost")
+    const { topic } = primeForHandleResult(zk, {
+      verifyResult: { verified: true, uniqueIdentifier: "uid-1", uniqueIdentifierType: 0 },
+    })
+    delete (zk as any).topicToPublicKey[topic]
+
+    await (zk as any).handleResult(topic)
+
+    const body = JSON.parse(fetchedBodies[0])
+    expect("requestId" in body).toBe(false)
   })
 
   test("does not submit when disableProofStorage is true", async () => {

--- a/packages/zkpassport-ui/package.json
+++ b/packages/zkpassport-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkpassport/ui",
-  "version": "0.15.7",
+  "version": "0.15.8",
   "description": "Drop-in QR verification card for ZKPassport. Vanilla JS by default; React component available at @zkpassport/ui/react.",
   "author": "ZKPassport",
   "license": "Apache-2.0",


### PR DESCRIPTION
Sends a request identifier alongside a submitted proof so the customer dashboard can link a stored proof back to the verification activity reported for that same request.