### PR TITLE
fix(sdk): reset CRS cache when the prior bb version is unknown

### DIFF
--- a/packages/zkpassport-sdk/src/bb-verifier.ts
+++ b/packages/zkpassport-sdk/src/bb-verifier.ts
@@ -50,12 +50,21 @@ export async function createUltraHonkVerifier(
 const BB_VERSION_KEY = "__zkpassport_bb_version"
 const BB_CRS_DB_NAME = "keyval-store"
 
-// Clear bb cache on v4 -> v5 due to default CRS size change
+// The v4 and v5 verifiers share bb.js's default CRS cache (IndexedDB
+// "keyval-store"), but their CRS layouts differ, so a cache written by one bb
+// version makes the other throw "object store not found" during initSRSChonk.
+// Reset the cache whenever the active bb version doesn't match the one that last
+// wrote it — INCLUDING the first run when the marker is absent (e.g. right after
+// upgrading from a build that populated the cache under a different marker, or
+// none at all). The previous default of "v4" for a missing marker let a stale
+// cache slip through unmodified on the v4 path and crash.
 async function clearStaleCrsCacheOnVersionChange(bbVersion: BBVersion): Promise<void> {
   if (typeof indexedDB === "undefined") return
   try {
     const store = typeof localStorage !== "undefined" ? localStorage : undefined
-    if ((store?.getItem(BB_VERSION_KEY) ?? "v4") === bbVersion) return
+    // A missing marker means we can't confirm which bb version wrote the cache,
+    // so treat it as a mismatch and reset rather than assuming "v4".
+    if (store?.getItem(BB_VERSION_KEY) === bbVersion) return
 
     let dbExists = true
     if (typeof indexedDB.databases === "function") {


### PR DESCRIPTION
## Problem

Client-side proof verification crashes in the browser with:

```
Using deprecated v4 UltraHonk Verifier
Uncaught (in promise) NotFoundError: Failed to execute 'transaction' on 'IDBDatabase':
  One of the specified object stores was not found.
    at async e.init            (bb.js)
    at async e.initSRSChonk
    at async verify → handleResult → handleEncryptedMessage
```

This is the same class of failure #232 ("Clear srs cache on bb version change") set out to fix, but it still reproduces on `0.16.1` for the **v4** verifier path.

## Root cause

`createUltraHonkVerifier` runs both the v4 and v5 backends against bb.js's **single default CRS cache** (IndexedDB `keyval-store`) — in the browser the `crsPath` split only applies to Node. Their CRS layouts differ, so a cache written by one bb version makes the other throw `object store not found` in `initSRSChonk`.

`clearStaleCrsCacheOnVersionChange` guards with:

```ts
if ((store?.getItem(BB_VERSION_KEY) ?? "v4") === bbVersion) return
```

On the **first run after upgrading** — when the marker is absent because the cache was populated by an earlier build (e.g. `0.16.0`, which used a different marker key / no `__zkpassport_bb_version`) — `getItem` returns `null`, defaults to `"v4"`, and for a v4-circuit proof `"v4" === "v4"` short-circuits **without clearing the stale cache**. bb.js then initialises against the mismatched DB and crashes.

## Fix

Treat a missing marker as an *unknown* prior version (a mismatch) and reset, instead of assuming `"v4"`:

```ts
if (store?.getItem(BB_VERSION_KEY) === bbVersion) return
```

Cost is a single one-time CRS re-download on the very first verification per browser; correctness is that the shared cache is always reconciled with the active bb version.

## Repro

Fresh browser whose `keyval-store` was populated by a prior `0.16.x` build, then verify a v4-circuit proof in the browser (e.g. via the `@zkpassport/ui` QR widget, `.gte("age",18).sanctions()`). Before: crashes in `initSRSChonk`. After: the stale cache is dropped and the verifier initialises cleanly.

## Notes / open question

- I couldn't run the repo's `bun`/`tsup` build in my environment (deps not installed), but the change is type-trivial (drops a nullish default from a `string | null` comparison) and no tests reference this function.
- Deeper concern for maintainers: because v4 and v5 share the one `keyval-store` DB, a single verification that mixes v4- and v5-circuit sub-proofs could still thrash/collide (the per-call `deleteDatabase` also resolves on `onblocked`, silently keeping a stale DB). A fuller fix would namespace the CRS cache per bb version so the two never share a DB — happy to follow up if you'd like that approach instead.