### PR TITLE
feat(sdk): returnBehavior "back" — let the app guide the user to the source app instead of opening a URL

### DIFF
--- a/packages/zkpassport-sdk/src/index.ts
+++ b/packages/zkpassport-sdk/src/index.ts
@@ -149,6 +149,7 @@ export class ZKPassport {
       uniqueIdentifierType: NullifierType | undefined
       oprfKeyId: string | null
       returnDeepLink: string | undefined
+      returnBehavior: "url" | "back" | undefined
     }
   > = {}
   private topicToPublicKey: Record<string, string> = {}
@@ -635,6 +636,13 @@ export class ZKPassport {
    * @param validity How many seconds ago the proof checking the expiry date of the ID should have been generated
    * @param mode The proof mode (e.g. "fast" / "compressed").
    * @param devMode Whether to enable dev mode. This will allow you to verify mock proofs (i.e. from ZKR)
+   * @param returnDeepLink Where the ZKPassport app sends the user after they finish (the "Return" button).
+   * Must be an absolute URL (a value without a scheme is ignored by the app). Note the OS opens an
+   * https value in the user's DEFAULT browser, which is not necessarily the browser the flow started in.
+   * @param returnBehavior How the ZKPassport app returns the user when they finish. "url" (default)
+   * opens `returnDeepLink`; "back" shows a "return to the app you came from" completion instead of
+   * opening a URL — for flows started in an in-app webview (Discord, X) or a non-default browser,
+   * where an https deep link would land the user in a browser without their session.
    * @returns The query builder object.
    */
   public async request({
@@ -653,6 +661,7 @@ export class ZKPassport {
     cloudProverUrl,
     bridgeUrl,
     returnDeepLink,
+    returnBehavior,
   }: {
     name?: string
     logo?: string
@@ -669,6 +678,7 @@ export class ZKPassport {
     cloudProverUrl?: string
     bridgeUrl?: string
     returnDeepLink?: string
+    returnBehavior?: "url" | "back"
   }): Promise<QueryBuilder> {
     if (topicOverride === "offline-query") {
       throw new Error("You cannot override the topic with 'offline-query'")
@@ -709,6 +719,7 @@ export class ZKPassport {
       uniqueIdentifierType: oprfKeyId ? NullifierType.SALTED : uniqueIdentifierType,
       oprfKeyId: oprfKeyId ?? null,
       returnDeepLink,
+      returnBehavior,
     }
 
     this.onRequestReceivedCallbacks[topic] = []
@@ -986,6 +997,9 @@ export class ZKPassport {
     }
     if (returnDeepLink) {
       url += `&r=${encodeURIComponent(returnDeepLink)}`
+    }
+    if (this.topicToLocalConfig[requestId].returnBehavior === "back") {
+      url += `&rb=back`
     }
     return url
   }

--- a/packages/zkpassport-utils/src/types/index.ts
+++ b/packages/zkpassport-utils/src/types/index.ts
@@ -425,6 +425,12 @@ export type QRCodeData = {
   uniqueIdentifierType: NullifierType | null
   oprfKeyId: string | null
   returnDeepLink: string | null
+  /** "back" = the app shows a "return to the app you came from" completion
+   * instead of opening `returnDeepLink` — for flows started in an in-app
+   * webview or a non-default browser, where an https deep link would land the
+   * user in a browser without their session. Optional for compatibility with
+   * requests from older SDKs. */
+  returnBehavior?: "url" | "back" | null
 }
 
 export interface JsonRpcRequest {


### PR DESCRIPTION
Hey guys — we've been trying to get the UX smooth for mobile users and ran into a challenge with cross-app browsers: `returnDeepLink` is opened via the OS, so an https value always lands in the **default** browser, which is often not where the user's signed-in session lives. A flow started in an in-app webview (Discord, X — no scheme can reopen those) or a non-default browser returns the user to a browser with none of their state. For links shared in chat apps this is the majority path, not an edge case.

This adds an opt-in `returnBehavior: "back"` on `request()`:

- transmitted as a new `rb=back` query param on the request URL (older apps simply ignore it);
- the app then shows a "Return to the app you came from" completion instead of opening a URL, so the user goes back via the OS affordance to the context that still holds their session;
- `"url"` (today's behavior) stays the default, and nothing changes unless the option is set.

**App-side implementation, ready to go:** your mobile-app repo doesn't accept fork PRs, so the companion change lives here — [starknetdev/mobile-app:feat/return-behavior-back](https://github.com/zkpassport/mobile-app/compare/main...starknetdev:mobile-app:feat/return-behavior-back) (parse `rb`, skip `Linking.openURL` on "back", "Return to the app you came from" completion copy; all touched files pass `tsc --noEmit`). Feel free to cherry-pick or tell us how you'd like it delivered.

Also adds JSDoc for `returnDeepLink` (it wasn't documented in the API reference alongside the other `request()` options).

Context: we currently work around this by rewriting returns into browser-reopen schemes (`googlechromes://`, `firefox://open-url`, `microsoft-edge-https://`) and coaching users through the round trip — all of which this option would make unnecessary. Happy to adjust the param name/shape to whatever fits your conventions.