### PR TITLE
fix(sdk): Validate registry roots as of the proof's date

### DIFF
--- a/packages/zkpassport-sdk/src/index.ts
+++ b/packages/zkpassport-sdk/src/index.ts
@@ -879,6 +879,7 @@ export class ZKPassport {
             })
             const params = this.getSolidityVerifierParameters({
               proof,
+              validityPeriodInSeconds: validity,
               domain: this.domain,
               scope,
               devMode,

--- a/packages/zkpassport-sdk/src/public-input-checker.ts
+++ b/packages/zkpassport-sdk/src/public-input-checker.ts
@@ -1844,11 +1844,13 @@ export class PublicInputChecker {
     queryResultErrors: any,
     outer?: boolean,
     devMode?: boolean,
+    // Point in time to check validity at, in seconds; defaults to now
+    timestamp?: number,
   ) {
     let isCorrect = true
     try {
       const registryClient = new RegistryClient({ chainId: devMode ? 11155111 : 1 })
-      const isValid = await registryClient.isCertificateRootValid(root)
+      const isValid = await registryClient.isCertificateRootValid(root, timestamp)
       if (!isValid) {
         console.warn("The ID was signed by an unrecognized root certificate")
         isCorrect = false
@@ -1881,11 +1883,13 @@ export class PublicInputChecker {
     root: string,
     queryResultErrors: any,
     devMode?: boolean,
+    // Same as above, see checkCertificateRegistryRoot
+    timestamp?: number,
   ) {
     let isCorrect = true
     try {
       const registryClient = new RegistryClient({ chainId: devMode ? 11155111 : 1 })
-      const isValid = await registryClient.isCircuitRootValid(root)
+      const isValid = await registryClient.isCircuitRootValid(root, timestamp)
       if (!isValid) {
         console.warn("The proof uses unrecognized circuits")
         isCorrect = false
@@ -2327,25 +2331,25 @@ export class PublicInputChecker {
     )
     let queryResultErrors: Partial<QueryResultErrors> = {}
 
+    const proofOrder = [
+      "sig_check_dsc",
+      "sig_check_id_data",
+      "data_check_integrity",
+      "disclose_bytes",
+      "compare_age",
+      "compare_birthdate",
+      "compare_expiry",
+      "exclusion_check_nationality",
+      "inclusion_check_nationality",
+      "exclusion_check_issuing_country",
+      "inclusion_check_issuing_country",
+      "bind",
+      "exclusion_check_sanctions",
+      "facematch",
+    ]
     // Since the order is important for the commitments, we need to sort the proofs
     // by their expected order: root signature check -> ID signature check -> integrity check -> disclosure
     const sortedProofs = proofs.sort((a, b) => {
-      const proofOrder = [
-        "sig_check_dsc",
-        "sig_check_id_data",
-        "data_check_integrity",
-        "disclose_bytes",
-        "compare_age",
-        "compare_birthdate",
-        "compare_expiry",
-        "exclusion_check_nationality",
-        "inclusion_check_nationality",
-        "exclusion_check_issuing_country",
-        "inclusion_check_issuing_country",
-        "bind",
-        "exclusion_check_sanctions",
-        "facematch",
-      ]
       const getIndex = (proof: ProofResult) => {
         const name = proof.name || ""
         return proofOrder.findIndex((p) => name.startsWith(p))
@@ -2353,10 +2357,27 @@ export class PublicInputChecker {
       return getIndex(a) - getIndex(b)
     })
 
+    // Registry roots are checked as of the proofs' own date, so older proofs still verify
+    const disclosureProofNames = proofOrder.slice(3)
+    const firstDisclosureProof = sortedProofs.find((p) =>
+      disclosureProofNames.some((name) => p.name?.startsWith(name)),
+    )
+    const bundleDate = firstDisclosureProof
+      ? getCurrentDateFromDisclosureProof(
+          getProofData(
+            firstDisclosureProof.proof as string,
+            getNumberOfPublicInputs(firstDisclosureProof.name!),
+          ),
+        )
+      : undefined
+    const bundleRootTimestamp = bundleDate ? Math.floor(bundleDate.getTime() / 1000) : undefined
+
     for (const proof of sortedProofs!) {
       const proofData = getProofData(proof.proof as string, getNumberOfPublicInputs(proof.name!))
       if (proof.name?.startsWith("outer")) {
         const isForEVM = proof.name?.startsWith("outer_evm")
+        const currentDate = getCurrentDateFromOuterProof(proofData)
+        const rootTimestamp = Math.floor(currentDate.getTime() / 1000)
         const certificateRegistryRoot = getCertificateRegistryRootFromOuterProof(proofData)
         const {
           isCorrect: isCorrectCertificateRegistryRoot,
@@ -2366,6 +2387,7 @@ export class PublicInputChecker {
           queryResultErrors,
           true,
           devMode,
+          rootTimestamp,
         )
         isCorrect = isCorrect && isCorrectCertificateRegistryRoot
         queryResultErrors = {
@@ -2381,6 +2403,7 @@ export class PublicInputChecker {
           circuitRegistryRoot.toString(16),
           queryResultErrors,
           devMode,
+          rootTimestamp,
         )
         isCorrect = isCorrect && isCorrectCircuitRegistryRoot
         queryResultErrors = {
@@ -2388,7 +2411,6 @@ export class PublicInputChecker {
           ...queryResultErrorsCircuitRegistryRoot,
         }
 
-        const currentDate = getCurrentDateFromOuterProof(proofData)
         const todayToCurrentDate = today.getTime() - currentDate.getTime()
         const expectedDifference = validity ? validity * 1000 : DEFAULT_VALIDITY * 1000
         if (todayToCurrentDate >= expectedDifference) {
@@ -2873,6 +2895,7 @@ export class PublicInputChecker {
           queryResultErrors,
           false,
           devMode,
+          bundleRootTimestamp,
         )
         isCorrect = isCorrect && isCorrectCertificateRegistryRoot
         queryResultErrors = {

--- a/packages/zkpassport-sdk/tests/public-input-checker.test.ts
+++ b/packages/zkpassport-sdk/tests/public-input-checker.test.ts
@@ -2489,8 +2489,14 @@ describe("PublicInputChecker - checkPublicInputs", () => {
     const commitment = 100n
     const nullifier = 42n
 
-    test("calls checkCertificateRegistryRoot for DSC proof", async () => {
+    test("calls checkCertificateRegistryRoot for DSC proof with the proof's date", async () => {
       const merkleRoot = 12345n
+      let checkArgs: unknown[] | undefined
+      ;(PublicInputChecker as unknown as Record<string, unknown>).checkCertificateRegistryRoot =
+        async (...args: unknown[]) => {
+          checkArgs = args
+          return { isCorrect: true, queryResultErrors: {} }
+        }
       const proofs: ProofResult[] = [
         {
           name: "sig_check_dsc_1234",
@@ -2519,8 +2525,58 @@ describe("PublicInputChecker - checkPublicInputs", () => {
         86400 * 365,
       )
 
-      // Verified by the test passing without RPC errors - the mock was called
-      expect(true).toBe(true)
+      expect(checkArgs).toBeDefined()
+      expect(checkArgs![0]).toBe(merkleRoot.toString(16))
+      // Root validity must be checked as of the proof's own date so proofs made
+      // against superseded roots remain verifiable
+      expect(checkArgs![4]).toBe(Number(todayTs))
+    })
+
+    test("does not mistake an oprf_auth proof for the bundle's date source", async () => {
+      const merkleRoot = 12345n
+      let checkArgs: unknown[] | undefined
+      ;(PublicInputChecker as unknown as Record<string, unknown>).checkCertificateRegistryRoot =
+        async (...args: unknown[]) => {
+          checkArgs = args
+          return { isCorrect: true, queryResultErrors: {} }
+        }
+      const proofs: ProofResult[] = [
+        {
+          name: "sig_check_dsc_1234",
+          proof: buildProofHex([merkleRoot, commitment]),
+          total: 3,
+        },
+        // oprf_auth has no date - its public inputs are comm_in and a curve point,
+        // not a timestamp - it must not be picked as the bundle's date source
+        {
+          name: "oprf_auth",
+          proof: buildProofHex([commitment, 1n, 2n]),
+          total: 3,
+        },
+        {
+          name: "compare_age",
+          proof: buildProofHex([commitment, todayTs, domainScopeHash, 0n, 0n, 0n, nullifier]),
+          total: 3,
+          committedInputs: {
+            compare_age: { minAge: 18, maxAge: 0 },
+          },
+        },
+      ]
+      const originalQuery: Query = { age: { gte: 18 } }
+      const queryResult: QueryResult = {
+        age: { gte: { expected: 18, result: true } },
+      }
+
+      await PublicInputChecker.checkPublicInputs(
+        domain,
+        proofs,
+        originalQuery,
+        queryResult,
+        86400 * 365,
+      )
+
+      expect(checkArgs).toBeDefined()
+      expect(checkArgs![4]).toBe(Number(todayTs))
     })
 
     test("fails when certificate registry root is invalid", async () => {


### PR DESCRIPTION
fix https://linear.app/aztec-labs/issue/ZKP-32/create-a-proof-verifier-api

Proofs made before the last registry root rotation fail verification with "unrecognized root certificate": root validity is checked as of verification time, but the mainnet registries only accept a root for 24h after rotation and roots rotate every 1–3 weeks. This makes stored proofs (e.g. for audit) unverifiable.
Related PRs:
- zkpassport/zkpassport-proof-verifier#3 — the generic `/verify` endpoint added there depends on this fix (via an SDK release) for verifying historic proofs and for `ignoreValidity` on EVM-verified bundles.
