### PR TITLE
feat(sdk): Allow .bind() on policy-driven requests

### DIFF
--- a/packages/zkpassport-sdk/src/index.ts
+++ b/packages/zkpassport-sdk/src/index.ts
@@ -413,7 +413,6 @@ export class ZKPassport {
             ? `0x${string}`
             : string | undefined,
       ) => {
-        this.assertNotPolicyLocked(topic, "bind")
         this.topicToConfig[topic].bind = {
           ...this.topicToConfig[topic].bind,
           [key]: value,
@@ -468,7 +467,10 @@ export class ZKPassport {
           )
         }
         const policy = this.findPolicy(this.dashboardConfig, id)
-        this.topicToConfig[topic] = policy.query
+        // Copy the query: the policy object is reused across requests, and a
+        // later .bind() writes into it
+        const { bind: _, ...policyQuery } = policy.query
+        this.topicToConfig[topic] = policyQuery
         // Policy locks scope; caller's purpose still wins when provided.
         const svc = this.topicToService[topic]
         if (svc) {
@@ -620,7 +622,9 @@ export class ZKPassport {
       )
     }
     if (Object.keys(this.topicToConfig[topic]).length > 0) {
-      throw new Error("Cannot combine .policy() with builder methods like .gte()/.disclose()/etc.")
+      throw new Error(
+        "Cannot combine .policy() with builder methods like .gte()/.disclose()/etc. Call .policy() first; only .bind() may follow it.",
+      )
     }
   }
 

--- a/packages/zkpassport-sdk/src/types.ts
+++ b/packages/zkpassport-sdk/src/types.ts
@@ -281,8 +281,8 @@ export type QueryBuilder<T extends "online" | "offline" = "online"> = {
   facematch: (mode?: FacematchMode) => QueryBuilder
   /**
    * Applies an immutable policy fetched from the dashboard. The policy's query,
-   * purpose and scope are locked; combining with builder methods or calling
-   * twice throws.
+   * purpose and scope are locked; combining with builder methods (except
+   * `.bind()`, which may follow it) or calling twice throws.
    * @param id The policy id (e.g. `'pol_xyz'`).
    */
   policy: (id: string) => QueryBuilder<T>

--- a/packages/zkpassport-sdk/tests/query-builder.test.ts
+++ b/packages/zkpassport-sdk/tests/query-builder.test.ts
@@ -617,11 +617,38 @@ describe("Policy-driven requests", () => {
     expect(() => builder.policy("pol_xyz")).toThrow(/more than once/i)
   })
 
-  test("every mutating builder method throws after .policy()", async () => {
+  test("every mutating builder method except .bind() throws after .policy()", async () => {
     const builder = (await zkPassport.request({})).policy("pol_xyz")
     expect(() => builder.eq("document_type", "passport")).toThrow(/policy-driven/i)
     expect(() => builder.disclose("firstname")).toThrow(/policy-driven/i)
     expect(() => builder.sanctions()).toThrow(/policy-driven/i)
+    expect(() => builder.bind("chain", "ethereum")).not.toThrow()
+  })
+
+  test(".bind() after .policy() adds bound data on top of the policy query", async () => {
+    const result = (await zkPassport.request({}))
+      .policy("pol_xyz")
+      .bind("user_address", "0x1234abcd")
+      .bind("chain", "ethereum")
+      .done()
+
+    expect(result.policy).toBe("pol_xyz")
+    expect(result.query).toEqual({
+      ...sampleConfig.policies[0].query,
+      bind: { user_address: "0x1234abcd", chain: "ethereum" },
+    })
+  })
+
+  test(".bind() before .policy() still throws", async () => {
+    const builder = await zkPassport.request({})
+    builder.bind("user_address", "0x1234abcd")
+    expect(() => builder.policy("pol_xyz")).toThrow(/Cannot combine \.policy\(\)/i)
+  })
+
+  test(".bind() on one policy-driven request does not leak into the next", async () => {
+    ;(await zkPassport.request({})).policy("pol_xyz").bind("chain", "ethereum")
+    const result = (await zkPassport.request({})).policy("pol_xyz").done()
+    expect(result.query.bind).toBeUndefined()
   })
 
   test(".policy() rejects an empty id", async () => {


### PR DESCRIPTION
fix https://github.com/zkpassport/zkpassport-packages/pull/239

## Why

It was not possible to use `.policy().bind()`, which was a mistake. The binded value (e.g. user's wallet address or the chain) only exist at the moment of the request. So policies could not be used for on-chain verification at all. 

## What changed

- `.bind()` is now the one builder method allowed after `.policy()`: `queryBuilder.policy("pol_xyz").bind("user_address", address).done()`.
- Everything else stays locked: the policy's query cannot be modified, `.policy()` can still only be called once, and `.bind()` before `.policy()` still throws.
- `.bind()` without a policy is untouched and behaves exactly as before.
