### PR TITLE
feat(sdk): Default facematch to strict mode

### DIFF
--- a/packages/zkpassport-sdk/src/index.ts
+++ b/packages/zkpassport-sdk/src/index.ts
@@ -456,7 +456,7 @@ export class ZKPassport {
         }
         return this.getZkPassportRequest(topic)
       },
-      facematch: (mode: FacematchMode = "regular") => {
+      facematch: (mode: FacematchMode = "strict") => {
         this.assertNotPolicyLocked(topic, "facematch")
         this.topicToConfig[topic].facematch = {
           mode,

--- a/packages/zkpassport-sdk/src/types.ts
+++ b/packages/zkpassport-sdk/src/types.ts
@@ -285,7 +285,7 @@ export type QueryBuilder<T extends "online" | "offline" = "online"> = {
   ) => QueryBuilder
   /**
    * Requires that the ID holder's face matches the photo on the ID.
-   * @param mode The mode to use for the face match. Defaults to "regular".
+   * @param mode The mode to use for the face match. Defaults to "strict".
    * @param mode "strict" - The user will have to go through an extensive liveness check to prevent spoofing making it more secure.
    * Best for high security requirements such as KYC.
    * @param mode "regular" - The user will only have to go through a basic liveness check to prevent spoofing, making it faster for the user.


### PR DESCRIPTION
### Key changes
- `.facematch()` with no argument now means `strict`. Passing a mode explicitly is unchanged.
