### PR TITLE
feat(sdk): Always enforce the scope check in verify()

### DIFF
--- a/packages/zkpassport-sdk/src/index.ts
+++ b/packages/zkpassport-sdk/src/index.ts
@@ -34,8 +34,8 @@ import {
   DashboardConfig,
   Policy,
   QueryResultErrors,
+  VerifierMode,
   VerificationResult,
-  VerifyParams,
 } from "./types"
 import { PublicInputChecker } from "./public-input-checker"
 import { SolidityVerifier } from "./solidity-verifier"
@@ -788,21 +788,30 @@ export class ZKPassport {
    * @returns An object containing the unique identifier associated to the user
    * and a boolean indicating whether the proofs were successfully verified.
    */
-  public async verify(params: VerifyParams): Promise<VerificationResult> {
-    if (!params?.originalQuery || !params?.queryResult) {
+  public async verify({
+    proofs,
+    originalQuery,
+    queryResult,
+    validity,
+    scope,
+    devMode = false,
+    writingDirectory,
+    oprfKeyId,
+    verifierMode = "auto",
+  }: {
+    proofs: Array<ProofResult>
+    originalQuery: Query
+    queryResult: QueryResult
+    validity?: number
+    scope?: string
+    devMode?: boolean
+    writingDirectory?: string
+    oprfKeyId?: string
+    verifierMode?: VerifierMode
+  }): Promise<VerificationResult> {
+    if (!originalQuery || !queryResult) {
       throw new Error("verify() requires `originalQuery` and `queryResult`")
     }
-    const {
-      proofs,
-      originalQuery,
-      queryResult,
-      validity,
-      scope,
-      devMode = false,
-      writingDirectory,
-      oprfKeyId,
-      verifierMode = "auto",
-    } = params
     const notVerified: VerificationResult = {
       uniqueIdentifier: undefined,
       uniqueIdentifierType: undefined,
@@ -813,9 +822,9 @@ export class ZKPassport {
     if (!proofs || proofs.length === 0) {
       return notVerified
     }
-    const sharedParams = { proofs, originalQuery, queryResult, validity, scope, devMode, oprfKeyId }
-    const localParams = { ...sharedParams, writingDirectory }
-    const apiParams = { ...sharedParams, domain: this.domain }
+    const params = { proofs, originalQuery, queryResult, validity, scope, devMode, oprfKeyId }
+    const localParams = { ...params, writingDirectory }
+    const apiParams = { ...params, domain: this.domain }
 
     if (verifierMode === "local") {
       return this.verifyLocally(localParams)
@@ -898,7 +907,7 @@ export class ZKPassport {
         // for testing purposes
         verified = false
         console.warn(
-          "You are trying to verify a mock proof. This is only allowed in dev mode. Set the `devMode` parameter to `true`.",
+          "You are trying to verify a mock proof. This is only allowed in dev mode. To enable dev mode, set the `devMode` parameter to `true` in the request function parameters.",
         )
       }
       // Only proceed with the proof verification if the public inputs are correct

--- a/packages/zkpassport-sdk/src/index.ts
+++ b/packages/zkpassport-sdk/src/index.ts
@@ -34,8 +34,8 @@ import {
   DashboardConfig,
   Policy,
   QueryResultErrors,
-  VerifierMode,
   VerificationResult,
+  VerifyParams,
 } from "./types"
 import { PublicInputChecker } from "./public-input-checker"
 import { SolidityVerifier } from "./solidity-verifier"
@@ -777,37 +777,32 @@ export class ZKPassport {
    * @param originalQuery The original query that was sent to the mobile app.
    * @param queryResult The query result to verify against
    * @param validity How many seconds ago the proof checking the expiry date of the ID should have been generated
-   * @param scope Scope this request to a specific use case
+   * @param scope The scope used in the original request, if any. Proofs generated for a different scope fail verification.
    * @param devMode Whether to enable dev mode. This will allow you to verify mock proofs (i.e. from ZKR)
    * @param writingDirectory The directory (e.g. `./tmp`) where the necessary temporary artifacts for verification are written to.
    * It should only be needed when running the `verify` function on a server with restricted write access (e.g. Vercel)
+   * @param oprfKeyId The OPRF key id used in the original request, if any.
    * @param verifierMode "local" verifies with the verifier bundled in this SDK, "api" with the
    * ZKPassport verifier API, and "auto" (default) verifies locally but defers to the API when
    * the local result is not verified — e.g. proofs from a newer bb version than this SDK supports.
    * @returns An object containing the unique identifier associated to the user
    * and a boolean indicating whether the proofs were successfully verified.
    */
-  public async verify({
-    proofs,
-    originalQuery,
-    queryResult,
-    validity,
-    scope,
-    devMode = false,
-    writingDirectory,
-    oprfKeyId,
-    verifierMode = "auto",
-  }: {
-    proofs: Array<ProofResult>
-    originalQuery: Query
-    queryResult: QueryResult
-    validity?: number
-    scope?: string
-    devMode?: boolean
-    writingDirectory?: string
-    oprfKeyId?: string
-    verifierMode?: VerifierMode
-  }): Promise<VerificationResult> {
+  public async verify(params: VerifyParams): Promise<VerificationResult> {
+    if (!params?.originalQuery || !params?.queryResult) {
+      throw new Error("verify() requires `originalQuery` and `queryResult`")
+    }
+    const {
+      proofs,
+      originalQuery,
+      queryResult,
+      validity,
+      scope,
+      devMode = false,
+      writingDirectory,
+      oprfKeyId,
+      verifierMode = "auto",
+    } = params
     const notVerified: VerificationResult = {
       uniqueIdentifier: undefined,
       uniqueIdentifierType: undefined,
@@ -818,9 +813,9 @@ export class ZKPassport {
     if (!proofs || proofs.length === 0) {
       return notVerified
     }
-    const params = { proofs, originalQuery, queryResult, validity, scope, devMode, oprfKeyId }
-    const localParams = { ...params, writingDirectory }
-    const apiParams = { ...params, domain: this.domain }
+    const sharedParams = { proofs, originalQuery, queryResult, validity, scope, devMode, oprfKeyId }
+    const localParams = { ...sharedParams, writingDirectory }
+    const apiParams = { ...sharedParams, domain: this.domain }
 
     if (verifierMode === "local") {
       return this.verifyLocally(localParams)
@@ -903,7 +898,7 @@ export class ZKPassport {
         // for testing purposes
         verified = false
         console.warn(
-          "You are trying to verify a mock proof. This is only allowed in dev mode. To enable dev mode, set the `devMode` parameter to `true` in the request function parameters.",
+          "You are trying to verify a mock proof. This is only allowed in dev mode. Set the `devMode` parameter to `true`.",
         )
       }
       // Only proceed with the proof verification if the public inputs are correct

--- a/packages/zkpassport-sdk/src/public-input-checker.ts
+++ b/packages/zkpassport-sdk/src/public-input-checker.ts
@@ -1812,7 +1812,7 @@ export class PublicInputChecker {
     scope?: string,
   ) {
     let isCorrect = true
-    if (domain && getServiceScopeHash(domain) !== getServiceScopeFromDisclosureProof(proofData)) {
+    if (getServiceScopeHash(domain) !== getServiceScopeFromDisclosureProof(proofData)) {
       console.warn("The proof comes from a different domain than the one expected")
       isCorrect = false
       if (!queryResultErrors[key as keyof QueryResultErrors]) {
@@ -1820,20 +1820,23 @@ export class PublicInputChecker {
       }
       queryResultErrors[key as keyof QueryResultErrors]!.scope = {
         expected: `Scope: ${getServiceScopeHash(domain).toString()}`,
-        received: `Scope: ${BigInt(proofData.publicInputs[1]).toString()}`,
+        received: `Scope: ${getServiceScopeFromDisclosureProof(proofData).toString()}`,
         message: "The proof comes from a different domain than the one expected",
       }
     }
-    if (scope && getScopeHash(scope) !== getServiceSubScopeFromDisclosureProof(proofData)) {
-      console.warn("The proof uses a different scope than the one expected")
+    if (getScopeHash(scope) !== getServiceSubScopeFromDisclosureProof(proofData)) {
+      const scopeErrorMessage = scope
+        ? "The proof uses a different scope than the one expected"
+        : "The proof uses a scope but none was passed to verify()"
+      console.warn(scopeErrorMessage)
       isCorrect = false
       if (!queryResultErrors[key as keyof QueryResultErrors]) {
         queryResultErrors[key as keyof QueryResultErrors] = {}
       }
       queryResultErrors[key as keyof QueryResultErrors]!.scope = {
         expected: `Scope: ${getScopeHash(scope).toString()}`,
-        received: `Scope: ${BigInt(proofData.publicInputs[2]).toString()}`,
-        message: "The proof uses a different scope than the one expected",
+        received: `Scope: ${getServiceSubScopeFromDisclosureProof(proofData).toString()}`,
+        message: scopeErrorMessage,
       }
     }
     return { isCorrect, queryResultErrors }
@@ -2456,7 +2459,7 @@ export class PublicInputChecker {
             },
           }
         }
-        if (domain && getServiceScopeHash(domain) !== getScopeFromOuterProof(proofData)) {
+        if (getServiceScopeHash(domain) !== getScopeFromOuterProof(proofData)) {
           console.warn("The proof comes from a different domain than the one expected")
           isCorrect = false
           queryResultErrors.outer = {
@@ -2468,15 +2471,18 @@ export class PublicInputChecker {
             },
           }
         }
-        if (scope && getScopeHash(scope) !== getSubscopeFromOuterProof(proofData)) {
-          console.warn("The proof uses a different scope than the one expected")
+        if (getScopeHash(scope) !== getSubscopeFromOuterProof(proofData)) {
+          const scopeErrorMessage = scope
+            ? "The proof uses a different scope than the one expected"
+            : "The proof uses a scope but none was passed to verify()"
+          console.warn(scopeErrorMessage)
           isCorrect = false
           queryResultErrors.outer = {
             ...queryResultErrors.outer,
             scope: {
               expected: `Scope: ${getScopeHash(scope).toString()}`,
               received: `Scope: ${getSubscopeFromOuterProof(proofData).toString()}`,
-              message: "The proof uses a different scope than the one expected",
+              message: scopeErrorMessage,
             },
           }
         }

--- a/packages/zkpassport-sdk/src/types.ts
+++ b/packages/zkpassport-sdk/src/types.ts
@@ -60,18 +60,6 @@ export type VerificationResult = {
   queryResultErrors?: Partial<QueryResultErrors>
 }
 
-export type VerifyParams = {
-  proofs: Array<ProofResult>
-  originalQuery: Query
-  queryResult: QueryResult
-  validity?: number
-  scope?: string
-  devMode?: boolean
-  writingDirectory?: string
-  oprfKeyId?: string
-  verifierMode?: VerifierMode
-}
-
 export type SolidityProofVerificationData = {
   vkeyHash: string
   proof: string

--- a/packages/zkpassport-sdk/src/types.ts
+++ b/packages/zkpassport-sdk/src/types.ts
@@ -60,6 +60,18 @@ export type VerificationResult = {
   queryResultErrors?: Partial<QueryResultErrors>
 }
 
+export type VerifyParams = {
+  proofs: Array<ProofResult>
+  originalQuery: Query
+  queryResult: QueryResult
+  validity?: number
+  scope?: string
+  devMode?: boolean
+  writingDirectory?: string
+  oprfKeyId?: string
+  verifierMode?: VerifierMode
+}
+
 export type SolidityProofVerificationData = {
   vkeyHash: string
   proof: string

--- a/packages/zkpassport-sdk/tests/public-input-checker.test.ts
+++ b/packages/zkpassport-sdk/tests/public-input-checker.test.ts
@@ -2093,6 +2093,27 @@ describe("PublicInputChecker - checkPublicInputs", () => {
 
       expect(queryResultErrors.age?.scope).toBeUndefined()
     })
+
+    test("fails when the proof has a scope but none is passed", async () => {
+      const proofSubscope = getScopeHash("my-scope")
+      const proofs = [makeDisclosureAge(domainScopeHash, proofSubscope)]
+      const originalQuery: Query = { age: { gte: 18 } }
+      const queryResult: QueryResult = {
+        age: { gte: { expected: 18, result: true } },
+      }
+
+      const { isCorrect, queryResultErrors } = await PublicInputChecker.checkPublicInputs(
+        domain,
+        proofs,
+        originalQuery,
+        queryResult,
+        86400 * 365,
+      )
+
+      expect(isCorrect).toBe(false)
+      expect(queryResultErrors.age?.scope?.message).toContain("none was passed")
+      expect(queryResultErrors.age?.scope?.received).toContain(proofSubscope.toString())
+    })
   })
 
   describe("non-outer proof path - current date validation", () => {
@@ -2390,6 +2411,47 @@ describe("PublicInputChecker - checkPublicInputs", () => {
       )
 
       expect(queryResultErrors.outer?.date).toBeUndefined()
+    })
+  })
+
+  describe("outer proof path - scope validation", () => {
+    const domain = "example.com"
+    const domainScopeHash = getServiceScopeHash(domain)
+    const nullifier = 42n
+
+    // Outer proof public inputs: [certRegistryRoot, circuitRegistryRoot, currentDate,
+    // serviceScope, subscope, paramCommitment, nullifierType, nullifier]
+    function makeScopedOuterProof(subscope: bigint): ProofResult {
+      return {
+        name: "outer_4",
+        proof: buildProofHex([
+          1n, // certRegistryRoot (mocked)
+          2n, // circuitRegistryRoot (mocked)
+          BigInt(getTodayTimestamp()),
+          domainScopeHash,
+          subscope,
+          0n, // paramCommitment
+          0n, // nullifierType
+          nullifier,
+        ]),
+        total: 1,
+        committedInputs: {},
+      }
+    }
+
+    test("fails when the outer proof has a scope but none is passed", async () => {
+      const proofs = [makeScopedOuterProof(getScopeHash("my-scope"))]
+
+      const { isCorrect, queryResultErrors } = await PublicInputChecker.checkPublicInputs(
+        domain,
+        proofs,
+        {},
+        {},
+        86400 * 365,
+      )
+
+      expect(isCorrect).toBe(false)
+      expect(queryResultErrors.outer?.scope?.message).toContain("none was passed")
     })
   })
 

--- a/packages/zkpassport-sdk/tests/verifier-api.test.ts
+++ b/packages/zkpassport-sdk/tests/verifier-api.test.ts
@@ -44,6 +44,13 @@ describe("verify() modes and the verifier API", () => {
     localSpy.mockRestore()
   })
 
+  test("rejects invalid parameters before verifying", async () => {
+    const zk = new ZKPassport("example.com")
+
+    await expect(zk.verify({ proofs, originalQuery } as any)).rejects.toThrow("queryResult")
+    expect(localSpy).not.toHaveBeenCalled()
+  })
+
   test("auto keeps a verified local result without calling the API", async () => {
     const localResult = { verified: true, uniqueIdentifier: "local-uid", uniqueIdentifierType: 1 }
     localSpy.mockResolvedValue(localResult)


### PR DESCRIPTION
Related to https://linear.app/aztec-labs/issue/ZKP-75/sdk-validate-verify-signature

This is mostly refactor/cleanup coming from analysis of the above ticket. Nothing really critical found.

We can merge or close.

Findings:
- `verify()` skipped the scope check when scope wasn't passed, so a proof made for one use case could pass for another. Bad parameters failed deep inside with cryptic errors.
- Scope mismatch errors displayed the wrong public input as the "received" value; they now show the proof's actual scope values.

Notes:
- Behavior change: proofs generated with a scope now fail verification unless the same `scope` is passed to `verify()`. This matches what the on-chain verifier already enforces.


---------

On your question _"Is scope relevant even if you have originalQuery?"_
- `scope` is independent of `originalQuery` and can't be derived from it.
`originalQuery` describes what was asked (age ≥ 18, nationality, etc.); scope describes which use case the proof was generated for, and it's baked into the proof's nullifier. The `Query` type doesn't contain scope at all.
