### PR TITLE
fix(registry-sdk,sdk,ui,utils): Remove TypeScript peer dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -78,9 +78,6 @@
         "@sinonjs/fake-timers": "^15.0.0",
         "keccak256": "^1.0.6",
       },
-      "peerDependencies": {
-        "typescript": "^5.0.0",
-      },
     },
     "packages/zkpassport-sdk": {
       "name": "@zkpassport/sdk",
@@ -105,9 +102,6 @@
         "@types/pako": "^2.0.3",
         "@types/ws": "^8.5.12",
       },
-      "peerDependencies": {
-        "typescript": "^5.0.0",
-      },
     },
     "packages/zkpassport-ui": {
       "name": "@zkpassport/ui",
@@ -127,7 +121,6 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18",
-        "typescript": "^5.0.0",
       },
       "optionalPeers": [
         "react",
@@ -156,9 +149,6 @@
         "date-fns": "^4.1.0",
         "i18n-iso-countries": "^7.13.0",
         "tslib": "^2.8.1",
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0",
       },
     },
   },

--- a/packages/registry-sdk/package.json
+++ b/packages/registry-sdk/package.json
@@ -56,8 +56,5 @@
     "@sinonjs/fake-timers": "^15.0.0",
     "keccak256": "^1.0.6"
   },
-  "peerDependencies": {
-    "typescript": "^5.0.0"
-  },
   "packageManager": "bun@1.3.1"
 }

--- a/packages/zkpassport-sdk/package.json
+++ b/packages/zkpassport-sdk/package.json
@@ -59,8 +59,5 @@
     "@types/pako": "^2.0.3",
     "@types/ws": "^8.5.12"
   },
-  "peerDependencies": {
-    "typescript": "^5.0.0"
-  },
   "packageManager": "bun@1.3.1"
 }

--- a/packages/zkpassport-ui/package.json
+++ b/packages/zkpassport-ui/package.json
@@ -67,8 +67,7 @@
   },
   "peerDependencies": {
     "react": ">=18",
-    "react-dom": ">=18",
-    "typescript": "^5.0.0"
+    "react-dom": ">=18"
   },
   "peerDependenciesMeta": {
     "react": {

--- a/packages/zkpassport-utils/package.json
+++ b/packages/zkpassport-utils/package.json
@@ -122,8 +122,5 @@
     "i18n-iso-countries": "^7.13.0",
     "tslib": "^2.8.1"
   },
-  "peerDependencies": {
-    "typescript": "^5.0.0"
-  },
   "packageManager": "bun@1.3.1"
 }

--- a/scripts/validate-package.sh
+++ b/scripts/validate-package.sh
@@ -14,6 +14,11 @@ echo "📦 Packing package..."
 PKG=$(bun pm pack --quiet | xargs)
 trap 'rm "$PKG"' EXIT
 
+# A typescript peer dependency breaks `npm install` for consumers on other TS
+# majors (npm enforces peer ranges; ERESOLVE). publint/attw don't check this.
+echo "🔍 Checking peerDependencies..."
+bun -e "require('./package.json').peerDependencies?.typescript && (console.error('ERROR: typescript must not be a peer dependency'), process.exit(1))"
+
 # Run publint validation
 echo "🔍 Running publint..."
 "$REPO_ROOT/node_modules/.bin/publint" "$PKG"


### PR DESCRIPTION
npm installs fail on TypeScript 6+ because we require TypeScript v5 as a peer dependency, which nothing we ship needs.

### Key changes
- Removed the TypeScript peer dependency from all four packages
- Package validation now blocks it from coming back

### Release note
Safe to publish in any order, but npm users only get the fix once all four packages are republished, bottom-up: utils → registry → sdk → ui.