### PR TITLE
feat(sdk,ui): Add onSuccess and move proof verification to the backend

### DIFF
--- a/packages/verify-popup/src/App.tsx
+++ b/packages/verify-popup/src/App.tsx
@@ -106,18 +106,10 @@ export function App() {
         onProofGenerated={(proof) =>
           send({ type: "proof-generated", index: proof.index, total: proof.total, name: proof.name })
         }
-        onResult={({ proofs, result, uniqueIdentifier, uniqueIdentifierType, verified, queryResultErrors }) => {
-          send({
-            type: "result",
-            proofs,
-            result,
-            uniqueIdentifier,
-            uniqueIdentifierType,
-            verified,
-            queryResultErrors,
-          })
-          // Close after showing the success screen
-          if (verified) scheduleClose(2500)
+        onSuccess={({ proofs, result }) => {
+          send({ type: "success", proofs, result })
+          // Close after showing the completion screen
+          scheduleClose(2500)
         }}
         onReject={() => {
           send({ type: "rejected" })

--- a/packages/zkpassport-sdk/README.md
+++ b/packages/zkpassport-sdk/README.md
@@ -43,7 +43,7 @@ const {
   onRequestReceived,
   onGeneratingProof,
   onProofGenerated,
-  onResult,
+  onSuccess,
   onReject,
   onError,
 } = queryBuilder
@@ -69,12 +69,10 @@ onGeneratingProof(() => {
 })
 
 // You probably don't need to use this callback
-// But if you want to get the proofs and verify them manually, it's here
+// It reports the progress as the proofs are generated one by one;
+// the full set arrives in onSuccess
 onProofGenerated(({ proof, vkeyHash, version, name }: ProofResult) => {
   // One of the proofs has been generated
-  // Here, you can retrieve the proof manually and verify it
-  // But note that the verification of the proofs is handled
-  // automatically by the SDK
   console.log("Proof generated", proof)
   console.log("Verification key hash", vkeyHash)
   console.log("Version", version)
@@ -82,36 +80,56 @@ onProofGenerated(({ proof, vkeyHash, version, name }: ProofResult) => {
 })
 
 // That's the callback you're looking for
-onResult(
-  ({
-    uniqueIdentifier,
-    verified,
-    result,
-  }: {
-    uniqueIdentifier: string
-    verified: boolean
-    result: QueryResult
-  }) => {
-    // All the proofs have been generated and the final result is available
-    console.log("firstname", result.firstname.disclose.result)
-    console.log("age over 18", result.age.gte.result)
-    console.log("nationality in EU", result.nationality.in.result)
-    console.log("nationality not from Scandinavia", result.nationality.out.result)
-    // You can also retrieved what were the values originally requested
-    console.log("age over", result.age.gte.expected)
-    console.log("nationality in", result.nationality.in.expected)
-    console.log("nationality not in", result.nationality.out.expected)
-    // You can make sure the proof are valid by checking verified is set to true
-    console.log("proofs are valid", verified)
-    // You can also retrieve the unique identifier associated to this request
-    // The assumption is that the unique identifier will be the same if coming
-    // from the same ID for the same domain name and scope
-    // So you can use it to identify if the user has already provided the proof
-    // for this specific use case
-    console.log("unique identifier", uniqueIdentifier)
-  },
-)
+onSuccess(({ proofs, result }: { proofs: ProofResult[]; result: QueryResult }) => {
+  // All the proofs have been generated and the result is available
+  console.log("firstname", result.firstname.disclose.result)
+  console.log("age over 18", result.age.gte.result)
+  console.log("nationality in EU", result.nationality.in.result)
+  console.log("nationality not from Scandinavia", result.nationality.out.result)
+  // You can also retrieve what were the values originally requested
+  console.log("age over", result.age.gte.expected)
+  console.log("nationality in", result.nationality.in.expected)
+  console.log("nationality not in", result.nationality.out.expected)
+  // The proofs are NOT verified at this point. A result checked in the browser
+  // can be tampered with, so send the proofs and the result to your backend
+  // and verify them there (see "Verifying the proofs" below)
+  fetch("/api/verify", { method: "POST", body: JSON.stringify({ proofs, result }) })
+})
 ```
+
+The deprecated `onResult` callback still verifies the proofs for you and returns a `verified` flag along with the `uniqueIdentifier`, but a flag delivered to the browser cannot be trusted. Use `onSuccess` and verify on your backend instead.
+
+### Verifying the proofs
+
+On your backend, recreate the original query so a tampered request cannot pass, then verify the proofs you received:
+
+```ts
+import { ZKPassport, EU_COUNTRIES } from "@zkpassport/sdk"
+
+const zkPassport = new ZKPassport("demo.zkpassport.id")
+
+const { query } = zkPassport
+  .createQuery()
+  .disclose("firstname")
+  .gte("age", 18)
+  .in("nationality", EU_COUNTRIES)
+  .out("nationality", ["Sweden", "Denmark"])
+  .done()
+
+const { verified, uniqueIdentifier } = await zkPassport.verify({
+  proofs,
+  originalQuery: query,
+  queryResult: result,
+  scope: "eu-adult-not-scandinavia",
+})
+
+// The unique identifier stays the same for the same ID, domain and scope,
+// so you can use it to tell if this user has already verified before
+console.log("proofs are valid", verified)
+console.log("unique identifier", uniqueIdentifier)
+```
+
+`verify()` checks the proofs locally and defers to the ZKPassport verifier API when the local result is not verified. Set `verifierMode` to `"local"` or `"api"` to force one.
 
 ### Using with Next.js
 

--- a/packages/zkpassport-sdk/README.md
+++ b/packages/zkpassport-sdk/README.md
@@ -14,6 +14,8 @@ npm install @zkpassport/sdk
 
 ## How to use
 
+For a drop-in QR card or verify button that wraps all of this, see [`@zkpassport/ui`](https://www.npmjs.com/package/@zkpassport/ui).
+
 ```ts
 import { ZKPassport, EU_COUNTRIES } from "@zkpassport/sdk"
 
@@ -26,17 +28,14 @@ const queryBuilder = await zkPassport.request({
   name: "ZKPassport",
   logo: "https://zkpassport.id/logo.png",
   purpose: "Prove you are an adult from the EU but not from Scandinavia",
-  // The scope is optional and can be used to scope the unique identifier
-  // of the request to a specific use case
-  // By default, the request's unique identifier is scoped to your domain name only
+  // Optional: ties the user's unique identifier to a use case;
+  // by default it is tied to your domain only
   scope: "eu-adult-not-scandinavia",
 })
 
-// Specify the data you want to disclose
-// Then you can call the `done` method to get the url and the callbacks to follow the progress
-// and get back the result along with the proof
-// The example below requests to disclose the firstname, prove the user is at least 18 years old,
-// prove the user is from the EU but not from a Scandinavian country (note that Norway is not in the EU)
+// Build the query; done() returns the request URL and the progress callbacks.
+// Here: disclose the first name, prove 18+, prove EU nationality but not Scandinavian
+// (Norway is already excluded — it is not in the EU)
 const {
   url,
   requestId,
@@ -57,9 +56,7 @@ const {
 // or transform it into a button if the user is on their phone
 
 onRequestReceived(() => {
-  // The user scanned the QR code or clicked the link to the request
-  // Essentially, this means the request popup is now opened
-  // on the user phone
+  // The user scanned the QR code or opened the link; the request is now on their phone
   console.log("Request received")
 })
 
@@ -71,7 +68,7 @@ onGeneratingProof(() => {
 // You probably don't need to use this callback
 // It reports the progress as the proofs are generated one by one;
 // the full set arrives in onSuccess
-onProofGenerated(({ proof, vkeyHash, version, name }: ProofResult) => {
+onProofGenerated(({ proof, vkeyHash, version, name }) => {
   // One of the proofs has been generated
   console.log("Proof generated", proof)
   console.log("Verification key hash", vkeyHash)
@@ -80,7 +77,7 @@ onProofGenerated(({ proof, vkeyHash, version, name }: ProofResult) => {
 })
 
 // That's the callback you're looking for
-onSuccess(({ proofs, result }: { proofs: ProofResult[]; result: QueryResult }) => {
+onSuccess(({ proofs, result }) => {
   // All the proofs have been generated and the result is available
   console.log("firstname", result.firstname.disclose.result)
   console.log("age over 18", result.age.gte.result)
@@ -93,7 +90,7 @@ onSuccess(({ proofs, result }: { proofs: ProofResult[]; result: QueryResult }) =
   // The proofs are NOT verified at this point. A result checked in the browser
   // can be tampered with, so send the proofs and the result to your backend
   // and verify them there (see "Verifying the proofs" below)
-  fetch("/api/verify", { method: "POST", body: JSON.stringify({ proofs, result }) })
+  fetch("/api/register", { method: "POST", body: JSON.stringify({ proofs, result }) })
 })
 ```
 
@@ -122,95 +119,62 @@ const { verified, uniqueIdentifier } = await zkPassport.verify({
   queryResult: result,
   scope: "eu-adult-not-scandinavia",
 })
+if (!verified) return { registered: false }
 
 // The unique identifier stays the same for the same ID, domain and scope,
-// so you can use it to tell if this user has already verified before
-console.log("proofs are valid", verified)
-console.log("unique identifier", uniqueIdentifier)
+// so it can act as the account key: store it in your DB with a uniqueness
+// constraint, and a duplicate means this person already has an account
+await db.users.insert({ zkpassportId: uniqueIdentifier })
+return { registered: true }
 ```
 
 `verify()` checks the proofs locally and defers to the ZKPassport verifier API when the local result is not verified. Set `verifierMode` to `"local"` or `"api"` to force one.
 
 ### Using with Next.js
 
-You can integrate `@zkpassport/sdk` into a Next.js application by creating a backend API route and calling it from your frontend.
+Request the proofs in the browser (with the "How to use" example above, or the drop-in card/button from `@zkpassport/ui`), then send them from `onSuccess` to an API route that verifies them:
 
-#### **Backend (API Route)**
+```ts
+onSuccess(async ({ proofs, result }) => {
+  await fetch("/api/register", { method: "POST", body: JSON.stringify({ proofs, result }) })
+})
+```
 
-**App Router:** `app/api/zkpassport/route.ts`
+**App Router:** `app/api/register/route.ts`
 
 ```typescript
 import { NextResponse } from "next/server"
 import { ZKPassport } from "@zkpassport/sdk"
 
-export async function GET() {
-  const zkPassport = new ZKPassport("demo.zkpassport.id") // Replace with your domain
-  const queryBuilder = await zkPassport.request({
-    name: "ZKPassport Demo",
-    logo: "https://via.placeholder.com/150",
-    purpose: "Verify user nationality and first name",
+const zkPassport = new ZKPassport("demo.zkpassport.id") // Replace with your domain
+
+export async function POST(request: Request) {
+  const { proofs, result } = await request.json()
+
+  // Recreate the original query so a tampered request cannot pass
+  const { query } = zkPassport.createQuery().gte("age", 18).done()
+
+  const { verified, uniqueIdentifier } = await zkPassport.verify({
+    proofs,
+    originalQuery: query,
+    queryResult: result,
+    scope: "age-check",
   })
-  const { url } = queryBuilder.disclose("nationality").disclose("firstname").done()
-  return NextResponse.json({ url })
+  if (!verified) return NextResponse.json({ registered: false })
+
+  // Store uniqueIdentifier in your DB as the user's key
+  return NextResponse.json({ registered: true })
 }
 ```
 
-#### **Frontend Example**
+## Working on the SDK
 
-**App Router:** `app/page.tsx`
-
-```tsx
-"use client"
-import { useEffect, useState } from "react"
-
-export default function Home() {
-  const [verificationUrl, setVerificationUrl] = useState<string | null>(null)
-
-  useEffect(() => {
-    fetch("/api/zkpassport")
-      .then((res) => res.json())
-      .then((data) => setVerificationUrl(data.url))
-      .catch(console.error)
-  }, [])
-
-  return (
-    <div>
-      <h1>ZKPassport Demo</h1>
-      {verificationUrl ? (
-        <a href={verificationUrl} target="_blank" rel="noopener noreferrer">
-          <button>Verify Identity</button>
-        </a>
-      ) : (
-        <p>Loading...</p>
-      )}
-    </div>
-  )
-}
-```
-
-## Local installation
-
-### Clone the repository
+The SDK lives in the [zkpassport-packages](https://github.com/zkpassport/zkpassport-packages) monorepo:
 
 ```sh
-git clone https://github.com/zkpassport/zkpassport-sdk.git
-cd zkpassport-sdk
-```
-
-### Install dependencies
-
-```sh
+git clone https://github.com/zkpassport/zkpassport-packages.git
+cd zkpassport-packages
 bun install
-```
-
-### Run Tests
-
-```sh
+cd packages/zkpassport-sdk
 bun test
 ```
-
-### Simulate Websocket Messages
-
-Simulate mobile websocket messages: `bun run scripts/simulate.ts mobile`
-
-Simulate frontend websocket messages: `bun run scripts/simulate.ts frontend`

--- a/packages/zkpassport-sdk/src/index.ts
+++ b/packages/zkpassport-sdk/src/index.ts
@@ -33,6 +33,7 @@ import {
   Policy,
   QueryResultErrors,
   RequestSuccess,
+  OnSuccessVerdict,
   VerifierMode,
   VerificationResult,
 } from "./types"
@@ -140,7 +141,10 @@ export class ZKPassport {
   private onGeneratingProofCallbacks: Record<string, Array<(topic: string) => void>> = {}
   private onBridgeConnectCallbacks: Record<string, Array<() => void>> = {}
   private onProofGeneratedCallbacks: Record<string, Array<(proof: ProofResult) => void>> = {}
-  private onSuccessCallbacks: Record<string, Array<(response: RequestSuccess) => void>> = {}
+  private onSuccessCallbacks: Record<
+    string,
+    Array<(response: RequestSuccess) => OnSuccessVerdict>
+  > = {}
   private onResultCallbacks: Record<
     string,
     Array<
@@ -195,9 +199,14 @@ export class ZKPassport {
     const requestSucceeded = !hasFailedProofs && proofs.length > 0
 
     if (requestSucceeded) {
-      await Promise.all(
-        this.onSuccessCallbacks[topic].map((callback) => callback({ proofs, result })),
-      )
+      // A throwing callback must not block proof storage or the onResult flow below
+      try {
+        await Promise.all(
+          this.onSuccessCallbacks[topic].map((callback) => callback({ proofs, result })),
+        )
+      } catch (reason) {
+        logger.error("onSuccess callback failed:", reason)
+      }
     }
 
     // Browser-only callers (no explicit domain) can't be authenticated; devMode submits would
@@ -546,7 +555,7 @@ export class ZKPassport {
             this.onBridgeConnectCallbacks[topic].push(callback),
           onProofGenerated: (callback: (proof: ProofResult) => void) =>
             this.onProofGeneratedCallbacks[topic].push(callback),
-          onSuccess: (callback: (response: RequestSuccess) => void) =>
+          onSuccess: (callback: (response: RequestSuccess) => OnSuccessVerdict) =>
             this.onSuccessCallbacks[topic].push(callback),
           onResult: (
             callback: (response: {

--- a/packages/zkpassport-sdk/src/index.ts
+++ b/packages/zkpassport-sdk/src/index.ts
@@ -32,6 +32,7 @@ import {
   DashboardConfig,
   Policy,
   QueryResultErrors,
+  RequestSuccess,
   VerifierMode,
   VerificationResult,
 } from "./types"
@@ -94,6 +95,15 @@ export {
 export * from "./types"
 export { createOfflineQuery } from "./offline-query"
 
+let onResultDeprecationWarned = false
+function warnOnResultDeprecated() {
+  if (onResultDeprecationWarned) return
+  onResultDeprecationWarned = true
+  console.warn(
+    "[zkpassport] onResult is deprecated. Use onSuccess and verify the proofs on your backend with verify().",
+  )
+}
+
 export class ZKPassport {
   private domain: string
   private domainProvided: boolean
@@ -107,6 +117,7 @@ export class ZKPassport {
       uniqueIdentifierType: NullifierType | undefined
       oprfKeyId: string | null
       returnDeepLink: string | undefined
+      verifierMode: VerifierMode | undefined
     }
   > = {}
   private topicToPublicKey: Record<string, string> = {}
@@ -129,6 +140,7 @@ export class ZKPassport {
   private onGeneratingProofCallbacks: Record<string, Array<(topic: string) => void>> = {}
   private onBridgeConnectCallbacks: Record<string, Array<() => void>> = {}
   private onProofGeneratedCallbacks: Record<string, Array<(proof: ProofResult) => void>> = {}
+  private onSuccessCallbacks: Record<string, Array<(response: RequestSuccess) => void>> = {}
   private onResultCallbacks: Record<
     string,
     Array<
@@ -174,14 +186,53 @@ export class ZKPassport {
   }
 
   private async handleResult(topic: string) {
-    logger.debug("Starting verification for topic:", topic)
+    logger.debug("Handling result for topic:", topic)
     const result = this.topicToResults[topic]
     // Clear the results straight away to avoid concurrency issues
     delete this.topicToResults[topic]
     const proofs = this.topicToProofs[topic]
-    // Verify the proofs and extract the unique identifier (aka nullifier) and the verification result
-    const { uniqueIdentifier, uniqueIdentifierType, verified, queryResultErrors } =
-      await this.verify({
+    const hasFailedProofs = this.topicToFailedProofCount[topic] > 0
+    const requestSucceeded = !hasFailedProofs && proofs.length > 0
+
+    if (requestSucceeded) {
+      await Promise.all(
+        this.onSuccessCallbacks[topic].map((callback) => callback({ proofs, result })),
+      )
+    }
+
+    // Browser-only callers (no explicit domain) can't be authenticated; devMode submits would
+    // pollute real-domain stats.
+    const devMode = this.topicToLocalConfig[topic]?.devMode === true
+    const proofStorageEnabled = this.topicToPolicy[topic]?.proofStorageEnabled === true
+    if (requestSucceeded && proofStorageEnabled && this.domainProvided && !devMode) {
+      void submitProof({
+        domain: this.domain,
+        proofs,
+        query: this.topicToConfig[topic],
+        queryResult: result,
+        scope: this.topicToService[topic]?.scope,
+        requestId: this.topicToPublicKey[topic],
+      })
+    }
+
+    // Verification only runs for the deprecated onResult listeners
+    if (this.onResultCallbacks[topic].length > 0) {
+      await this.verifyAndReportResult(topic, proofs, result, hasFailedProofs)
+    }
+
+    delete this.topicToProofs[topic]
+    delete this.topicToFailedProofCount[topic]
+  }
+
+  private async verifyAndReportResult(
+    topic: string,
+    proofs: Array<ProofResult>,
+    result: QueryResult,
+    hasFailedProofs: boolean,
+  ) {
+    let verification: VerificationResult
+    try {
+      verification = await this.verify({
         proofs,
         originalQuery: this.topicToConfig[topic],
         queryResult: result,
@@ -189,25 +240,15 @@ export class ZKPassport {
         scope: this.topicToService[topic]?.scope,
         devMode: this.topicToLocalConfig[topic]?.devMode,
         oprfKeyId: this.topicToLocalConfig[topic]?.oprfKeyId ?? undefined,
+        verifierMode: this.topicToLocalConfig[topic]?.verifierMode,
       })
-    logger.debug("Verification complete, verified:", verified)
-    const hasFailedProofs = this.topicToFailedProofCount[topic] > 0
-    const finalVerified = hasFailedProofs ? false : verified
-    // Browser-only callers (no explicit domain) can't be authenticated; devMode submits would
-    // pollute real-domain stats.
-    const devMode = this.topicToLocalConfig[topic]?.devMode === true
-    const proofStorageEnabled = this.topicToPolicy[topic]?.proofStorageEnabled === true
-    if (finalVerified && proofStorageEnabled && this.domainProvided && !devMode) {
-      void submitProof({
-        domain: this.domain,
-        proofs: this.topicToProofs[topic],
-        query: this.topicToConfig[topic],
-        queryResult: result,
-        scope: this.topicToService[topic]?.scope,
-        requestId: this.topicToPublicKey[topic],
-      })
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e)
+      await Promise.all(this.onErrorCallbacks[topic].map((callback) => callback(message)))
+      return
     }
-    delete this.topicToProofs[topic]
+    const { uniqueIdentifier, uniqueIdentifierType, verified, queryResultErrors } = verification
+    logger.debug("Verification complete, verified:", verified)
     await Promise.all(
       this.onResultCallbacks[topic].map((callback) =>
         callback({
@@ -223,8 +264,6 @@ export class ZKPassport {
         }),
       ),
     )
-    // Clear the expected proof count and failed proof count
-    delete this.topicToFailedProofCount[topic]
   }
 
   /**
@@ -507,6 +546,8 @@ export class ZKPassport {
             this.onBridgeConnectCallbacks[topic].push(callback),
           onProofGenerated: (callback: (proof: ProofResult) => void) =>
             this.onProofGeneratedCallbacks[topic].push(callback),
+          onSuccess: (callback: (response: RequestSuccess) => void) =>
+            this.onSuccessCallbacks[topic].push(callback),
           onResult: (
             callback: (response: {
               uniqueIdentifier: string | undefined
@@ -517,7 +558,10 @@ export class ZKPassport {
               proofs: ProofResult[]
               sdkInstance: ZKPassport
             }) => void,
-          ) => this.onResultCallbacks[topic].push(callback),
+          ) => {
+            warnOnResultDeprecated()
+            this.onResultCallbacks[topic].push(callback)
+          },
           onReject: (callback: () => void) => this.onRejectCallbacks[topic].push(callback),
           onError: (callback: (error: string) => void) =>
             this.onErrorCallbacks[topic].push(callback),
@@ -618,6 +662,7 @@ export class ZKPassport {
    * @param validity How many seconds ago the proof checking the expiry date of the ID should have been generated
    * @param mode The proof mode (e.g. "fast" / "compressed").
    * @param devMode Whether to enable dev mode. This will allow you to verify mock proofs (i.e. from ZKR)
+   * @param verifierMode How the received proofs are verified: "local", "api" or "auto" (default).
    * @returns The query builder object.
    */
   public async request({
@@ -636,6 +681,7 @@ export class ZKPassport {
     cloudProverUrl,
     bridgeUrl,
     returnDeepLink,
+    verifierMode,
   }: {
     name?: string
     logo?: string
@@ -652,6 +698,7 @@ export class ZKPassport {
     cloudProverUrl?: string
     bridgeUrl?: string
     returnDeepLink?: string
+    verifierMode?: VerifierMode
   }): Promise<QueryBuilder> {
     if (topicOverride === "offline-query") {
       throw new Error("You cannot override the topic with 'offline-query'")
@@ -698,12 +745,14 @@ export class ZKPassport {
       uniqueIdentifierType: oprfKeyId ? NullifierType.SALTED : uniqueIdentifierType,
       oprfKeyId: oprfKeyId ?? null,
       returnDeepLink,
+      verifierMode,
     }
 
     this.onRequestReceivedCallbacks[topic] = []
     this.onGeneratingProofCallbacks[topic] = []
     this.onBridgeConnectCallbacks[topic] = []
     this.onProofGeneratedCallbacks[topic] = []
+    this.onSuccessCallbacks[topic] = []
     this.onResultCallbacks[topic] = []
     this.onRejectCallbacks[topic] = []
     this.onErrorCallbacks[topic] = []

--- a/packages/zkpassport-sdk/src/popup/client.ts
+++ b/packages/zkpassport-sdk/src/popup/client.ts
@@ -1,4 +1,5 @@
 import type { Query } from "@zkpassport/utils"
+import type { OnSuccessVerdict } from "../types"
 import {
   DEFAULT_POPUP_URL,
   isPopupMessage,
@@ -12,7 +13,12 @@ export type PopupCallbacks = {
   onRequestReceived?: () => void
   onGeneratingProof?: () => void
   onProofGenerated?: (progress: { index?: number; total?: number; name?: string }) => void
-  onSuccess?: (response: Omit<PopupSuccess, "zkpassport" | "type">) => void
+  /**
+   * All proofs arrived (not verified yet — verify them on your backend).
+   * The `@zkpassport/ui` components wait for this callback: return `false` (or throw) to show
+   * the error state. This raw popup client ignores the return value.
+   */
+  onSuccess?: (response: Omit<PopupSuccess, "zkpassport" | "type">) => OnSuccessVerdict
   onReject?: () => void
   onError?: (message: string) => void
   // Fired when the user closes the popup before a result was produced

--- a/packages/zkpassport-sdk/src/popup/client.ts
+++ b/packages/zkpassport-sdk/src/popup/client.ts
@@ -13,11 +13,6 @@ export type PopupCallbacks = {
   onRequestReceived?: () => void
   onGeneratingProof?: () => void
   onProofGenerated?: (progress: { index?: number; total?: number; name?: string }) => void
-  /**
-   * All proofs arrived (not verified yet — verify them on your backend).
-   * The `@zkpassport/ui` components wait for this callback: return `false` (or throw) to show
-   * the error state. This raw popup client ignores the return value.
-   */
   onSuccess?: (response: Omit<PopupSuccess, "zkpassport" | "type">) => OnSuccessVerdict
   onReject?: () => void
   onError?: (message: string) => void

--- a/packages/zkpassport-sdk/src/popup/client.ts
+++ b/packages/zkpassport-sdk/src/popup/client.ts
@@ -6,13 +6,13 @@ import {
   type PopupRequestConfig,
 } from "./protocol"
 
-export type PopupResult = Extract<PopupEventMessage, { type: "result" }>
+export type PopupSuccess = Extract<PopupEventMessage, { type: "success" }>
 
 export type PopupCallbacks = {
   onRequestReceived?: () => void
   onGeneratingProof?: () => void
   onProofGenerated?: (progress: { index?: number; total?: number; name?: string }) => void
-  onResult?: (result: Omit<PopupResult, "zkpassport" | "type">) => void
+  onSuccess?: (response: Omit<PopupSuccess, "zkpassport" | "type">) => void
   onReject?: () => void
   onError?: (message: string) => void
   // Fired when the user closes the popup before a result was produced
@@ -110,10 +110,10 @@ export function openVerificationPopup(
       case "proof-generated":
         callbacks.onProofGenerated?.({ index: data.index, total: data.total, name: data.name })
         break
-      case "result": {
+      case "success": {
         finished = true
-        const { zkpassport: _z, type: _t, ...result } = data
-        callbacks.onResult?.(result)
+        const { zkpassport: _z, type: _t, ...response } = data
+        callbacks.onSuccess?.(response)
         break
       }
       case "rejected":

--- a/packages/zkpassport-sdk/src/popup/protocol.ts
+++ b/packages/zkpassport-sdk/src/popup/protocol.ts
@@ -1,5 +1,4 @@
 import type { NullifierType, ProofMode, ProofResult, Query, QueryResult } from "@zkpassport/utils"
-import type { QueryResultErrors } from "../types"
 
 export const DEFAULT_POPUP_URL = "https://verify.zkpassport.id"
 
@@ -36,13 +35,9 @@ export type PopupEventMessage =
     }
   | {
       zkpassport: true
-      type: "result"
+      type: "success"
       proofs: ProofResult[]
       result: QueryResult
-      uniqueIdentifier: string | undefined
-      uniqueIdentifierType: NullifierType | undefined
-      verified: boolean
-      queryResultErrors?: Partial<QueryResultErrors>
     }
   | { zkpassport: true; type: "rejected" }
   | { zkpassport: true; type: "error"; message: string }

--- a/packages/zkpassport-sdk/src/types.ts
+++ b/packages/zkpassport-sdk/src/types.ts
@@ -107,6 +107,10 @@ export type RequestSuccess = {
   result: QueryResult
 }
 
+// What an onSuccess handler may return: false (or a promise resolving to false)
+// makes the UI components show their error state instead of success
+export type OnSuccessVerdict = void | boolean | Promise<void | boolean>
+
 export type QueryBuilderResult = {
   /**
    * The URL of the request.
@@ -154,9 +158,11 @@ export type QueryBuilderResult = {
    * Called when the user has completed the request and all proofs were received.
    *
    * The proofs are not verified at this point: send them along with the result
-   * to your backend and verify them there with `verify()`.
+   * to your backend and verify them there with `verify()`. The UI components wait
+   * for this callback before showing their success state; return `false` (or throw)
+   * to show the error state instead, e.g. when your backend rejects the proofs.
    */
-  onSuccess: (callback: (response: RequestSuccess) => void) => void
+  onSuccess: (callback: (response: RequestSuccess) => OnSuccessVerdict) => void
   /**
    * Called when the user has sent the query result.
    *

--- a/packages/zkpassport-sdk/src/types.ts
+++ b/packages/zkpassport-sdk/src/types.ts
@@ -101,6 +101,12 @@ export type DashboardConfig = {
   policies: Policy[]
 }
 
+// The completed request's raw proofs and query result, before any verification
+export type RequestSuccess = {
+  proofs: ProofResult[]
+  result: QueryResult
+}
+
 export type QueryBuilderResult = {
   /**
    * The URL of the request.
@@ -145,11 +151,21 @@ export type QueryBuilderResult = {
    */
   onProofGenerated: (callback: (proof: ProofResult) => void) => void
   /**
+   * Called when the user has completed the request and all proofs were received.
+   *
+   * The proofs are not verified at this point: send them along with the result
+   * to your backend and verify them there with `verify()`.
+   */
+  onSuccess: (callback: (response: RequestSuccess) => void) => void
+  /**
    * Called when the user has sent the query result.
    *
    * The response contains the unique identifier associated to the user,
    * your domain name and chosen scope, along with the query result and whether
    * the proofs were successfully verified.
+   *
+   * @deprecated The verified flag can be tampered with in the browser. Use `onSuccess`
+   * and verify the proofs on your backend with `verify()`.
    */
   onResult: (
     callback: (response: {

--- a/packages/zkpassport-sdk/tests/popup.test.ts
+++ b/packages/zkpassport-sdk/tests/popup.test.ts
@@ -101,16 +101,16 @@ describe("openVerificationPopup", () => {
     ;(globalThis as any).window = fakeWindow
     try {
       const events: string[] = []
-      let resultPayload: unknown = null
+      let successPayload: unknown = null
       const handle = openVerificationPopup({
         popupUrl: "https://verify.zkpassport.id",
         request: { name: "Test", mode: "fast", devMode: true },
         query: { age: { gte: 18 } },
         callbacks: {
           onRequestReceived: () => events.push("request-received"),
-          onResult: (result) => {
-            events.push("result")
-            resultPayload = result
+          onSuccess: (response) => {
+            events.push("success")
+            successPayload = response
           },
           onError: (message) => events.push(`error:${message}`),
         },
@@ -140,18 +140,15 @@ describe("openVerificationPopup", () => {
       )
       emit("https://verify.zkpassport.id", {
         zkpassport: true,
-        type: "result",
-        proofs: [],
+        type: "success",
+        proofs: [{ proof: "0x1" }],
         result: {},
-        uniqueIdentifier: "0x1",
-        uniqueIdentifierType: undefined,
-        verified: true,
       })
-      expect(events).toEqual(["request-received", "result"])
+      expect(events).toEqual(["request-received", "success"])
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect((resultPayload as any).verified).toBe(true)
+      expect((successPayload as any).proofs).toEqual([{ proof: "0x1" }])
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect((resultPayload as any).zkpassport).toBeUndefined()
+      expect((successPayload as any).zkpassport).toBeUndefined()
 
       handle!.close()
       expect(popup.closed).toBe(true)
@@ -161,33 +158,35 @@ describe("openVerificationPopup", () => {
     }
   })
 
-  test("keeps listening after an unverified result, so a retry still reaches the page", () => {
+  test("keeps listening after an error, so a retry still reaches the page", () => {
     const { fakeWindow, emit } = setupFakeWindow()
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ;(globalThis as any).window = fakeWindow
     try {
-      const outcomes: boolean[] = []
+      const events: string[] = []
       openVerificationPopup({
         popupUrl: "https://verify.zkpassport.id",
         request: {},
         query: {},
-        callbacks: { onResult: (result) => outcomes.push(result.verified) },
+        callbacks: {
+          onError: (message) => events.push(`error:${message}`),
+          onSuccess: () => events.push("success"),
+        },
       })
-      const sendResult = (verified: boolean) =>
-        emit("https://verify.zkpassport.id", {
-          zkpassport: true,
-          type: "result",
-          proofs: [],
-          result: {},
-          uniqueIdentifier: "0x1",
-          uniqueIdentifierType: undefined,
-          verified,
-        })
 
-      sendResult(false)
-      sendResult(true)
+      emit("https://verify.zkpassport.id", {
+        zkpassport: true,
+        type: "error",
+        message: "proof failed",
+      })
+      emit("https://verify.zkpassport.id", {
+        zkpassport: true,
+        type: "success",
+        proofs: [],
+        result: {},
+      })
 
-      expect(outcomes).toEqual([false, true])
+      expect(events).toEqual(["error:proof failed", "success"])
     } finally {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       delete (globalThis as any).window

--- a/packages/zkpassport-sdk/tests/proof-submission.test.ts
+++ b/packages/zkpassport-sdk/tests/proof-submission.test.ts
@@ -20,21 +20,16 @@ describe("Proof submission", () => {
     }) as unknown as typeof globalThis.fetch
   }
 
-  // Seed the private state that handleResult reads, and override verify()
-  // so the test does not need to drag in bb.js / the proof registry.
+  // Seed the private state that handleResult reads, so no bridge is needed.
+  // Submission does not depend on verification, which only runs for onResult listeners.
   function primeForHandleResult(
     zk: ZKPassport,
     opts: {
       topic?: string
-      verifyResult: {
-        verified: boolean
-        uniqueIdentifier?: string
-        uniqueIdentifierType?: number
-      }
       failedProofs?: number
       // Defaults to a storage-enabled policy; pass null to simulate a self-serve request.
       policy?: { id: string; version: number; proofStorageEnabled: boolean } | null
-    },
+    } = {},
   ) {
     const topic = opts.topic ?? "topic-1"
     const policy =
@@ -60,8 +55,8 @@ describe("Proof submission", () => {
     if (policy) i.topicToPolicy[topic] = policy
     i.topicToPublicKey[topic] = "04deadbeefpubkey"
     i.topicToFailedProofCount[topic] = opts.failedProofs ?? 0
+    i.onSuccessCallbacks[topic] = []
     i.onResultCallbacks[topic] = []
-    i.verify = async () => opts.verifyResult
     return { topic, proof }
   }
 
@@ -77,9 +72,7 @@ describe("Proof submission", () => {
 
   test("submits proof when the request ran a policy with proof storage enabled", async () => {
     const zk = new ZKPassport("localhost")
-    const { topic } = primeForHandleResult(zk, {
-      verifyResult: { verified: true, uniqueIdentifier: "uid-1", uniqueIdentifierType: 0 },
-    })
+    const { topic } = primeForHandleResult(zk)
 
     await (zk as any).handleResult(topic)
 
@@ -99,10 +92,7 @@ describe("Proof submission", () => {
 
   test("does not submit for a self-serve request (no policy)", async () => {
     const zk = new ZKPassport("localhost")
-    const { topic } = primeForHandleResult(zk, {
-      verifyResult: { verified: true, uniqueIdentifier: "uid-1", uniqueIdentifierType: 0 },
-      policy: null,
-    })
+    const { topic } = primeForHandleResult(zk, { policy: null })
 
     await (zk as any).handleResult(topic)
 
@@ -112,7 +102,6 @@ describe("Proof submission", () => {
   test("does not submit when the policy has proof storage disabled", async () => {
     const zk = new ZKPassport("localhost")
     const { topic } = primeForHandleResult(zk, {
-      verifyResult: { verified: true, uniqueIdentifier: "uid-1", uniqueIdentifierType: 0 },
       policy: { id: "pol_xyz", version: 3, proofStorageEnabled: false },
     })
 
@@ -123,9 +112,7 @@ describe("Proof submission", () => {
 
   test("omits requestId when the bridge public key is unavailable", async () => {
     const zk = new ZKPassport("localhost")
-    const { topic } = primeForHandleResult(zk, {
-      verifyResult: { verified: true, uniqueIdentifier: "uid-1", uniqueIdentifierType: 0 },
-    })
+    const { topic } = primeForHandleResult(zk)
     delete (zk as any).topicToPublicKey[topic]
 
     await (zk as any).handleResult(topic)
@@ -136,9 +123,7 @@ describe("Proof submission", () => {
 
   test("does not submit when devMode is enabled", async () => {
     const zk = new ZKPassport("localhost")
-    const { topic } = primeForHandleResult(zk, {
-      verifyResult: { verified: true, uniqueIdentifier: "uid-1", uniqueIdentifierType: 0 },
-    })
+    const { topic } = primeForHandleResult(zk)
     ;(zk as any).topicToLocalConfig[topic].devMode = true
 
     await (zk as any).handleResult(topic)
@@ -146,12 +131,9 @@ describe("Proof submission", () => {
     expect(fetchedUrls).toEqual([])
   })
 
-  test("does not submit when any proof failed to generate, even if verify() reports success", async () => {
+  test("does not submit when any proof failed to generate", async () => {
     const zk = new ZKPassport("localhost")
-    const { topic } = primeForHandleResult(zk, {
-      verifyResult: { verified: true, uniqueIdentifier: "uid-1", uniqueIdentifierType: 0 },
-      failedProofs: 1,
-    })
+    const { topic } = primeForHandleResult(zk, { failedProofs: 1 })
 
     await (zk as any).handleResult(topic)
 

--- a/packages/zkpassport-sdk/tests/verifier-api.test.ts
+++ b/packages/zkpassport-sdk/tests/verifier-api.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test"
-import { ZKPassport } from "../src/index"
+import { ZKPassport, type VerifierMode } from "../src/index"
 
 describe("verify() modes and the verifier API", () => {
   let originalFetch: typeof globalThis.fetch
@@ -139,5 +139,75 @@ describe("verify() modes and the verifier API", () => {
     const result = await zk.verify({ proofs, originalQuery, queryResult, verifierMode: "api" })
 
     expect(result).toEqual({ ...notVerified, queryResultErrors } as any)
+  })
+
+  // Seed the private state handleResult reads, so no bridge is needed
+  function primeForHandleResult(zk: ZKPassport, topic: string, verifierMode?: VerifierMode) {
+    const i = zk as any
+    i.topicToProofs[topic] = proofs
+    i.topicToResults[topic] = queryResult
+    i.topicToConfig[topic] = originalQuery
+    i.topicToLocalConfig[topic] = { validity: 0, devMode: false, oprfKeyId: null, verifierMode }
+    i.topicToService[topic] = { name: "n", logo: "l", purpose: "p" }
+    i.topicToFailedProofCount[topic] = 0
+    i.onSuccessCallbacks[topic] = []
+    i.onResultCallbacks[topic] = []
+    i.onErrorCallbacks[topic] = []
+    return i
+  }
+
+  test("handleResult fires onSuccess with the proofs and skips verification", async () => {
+    const zk = primeForHandleResult(new ZKPassport("example.com"), "topic-1")
+    let verifyCalls = 0
+    zk.verify = async () => {
+      verifyCalls++
+      return notVerified
+    }
+    const received: any[] = []
+    zk.onSuccessCallbacks["topic-1"] = [(response: any) => received.push(response)]
+
+    await zk.handleResult("topic-1")
+
+    expect(received).toEqual([{ proofs, result: queryResult }])
+    expect(verifyCalls).toBe(0)
+  })
+
+  test("handleResult does not fire onSuccess when a proof failed to generate", async () => {
+    const zk = primeForHandleResult(new ZKPassport("example.com"), "topic-1")
+    zk.topicToFailedProofCount["topic-1"] = 1
+    const received: any[] = []
+    zk.onSuccessCallbacks["topic-1"] = [(response: any) => received.push(response)]
+
+    await zk.handleResult("topic-1")
+
+    expect(received).toEqual([])
+  })
+
+  test("handleResult verifies with the verifierMode given to request() when onResult is used", async () => {
+    const zk = primeForHandleResult(new ZKPassport("example.com"), "topic-1", "api")
+    zk.onResultCallbacks["topic-1"] = [() => {}]
+    let seenMode: string | undefined
+    zk.verify = async (args: any) => {
+      seenMode = args.verifierMode
+      return notVerified
+    }
+
+    await zk.handleResult("topic-1")
+
+    expect(seenMode).toBe("api")
+  })
+
+  test("handleResult reports a verify() failure through onError", async () => {
+    const zk = primeForHandleResult(new ZKPassport("example.com"), "topic-1", "local")
+    zk.onResultCallbacks["topic-1"] = [() => {}]
+    zk.verify = async () => {
+      throw new Error("verifier crashed")
+    }
+    const errors: string[] = []
+    zk.onErrorCallbacks["topic-1"] = [(message: string) => errors.push(message)]
+
+    await zk.handleResult("topic-1")
+
+    expect(errors).toEqual(["verifier crashed"])
   })
 })

--- a/packages/zkpassport-ui/README.md
+++ b/packages/zkpassport-ui/README.md
@@ -162,7 +162,7 @@ Styles auto-inject as a `<style>` tag wrapped in `@layer zkpassport`, so host ap
 import "@zkpassport/ui/styles.css"
 ```
 
-The button reads CSS custom properties for light restyling — `--zkp-btn-bg`, `-fg`, `-border`, `-radius`, `-padding`, `-font`, `-font-size`, `-letter-spacing`, `-text-transform`, plus `--zkp-verify-success`, `-error` for the verified and failed states. Set them on the mount element or any ancestor.
+The button reads CSS custom properties for light restyling — `--zkp-btn-bg`, `-fg`, `-border-color`, `-radius`, `-padding`, `-font`, `-font-size`, `-letter-spacing`, `-text-transform`, plus `--zkp-btn-success`, `-error` for the verified and failed states. Set them on the mount element or any ancestor.
 
 To resize the button, set `--zkp-btn-font-size`; the icon, gap and padding are in `em`, so they scale with it. Use `--zkp-btn-padding` on top of that to make it chunkier or tighter than the default proportions.
 

--- a/packages/zkpassport-ui/README.md
+++ b/packages/zkpassport-ui/README.md
@@ -21,8 +21,9 @@ export default function Page() {
       purpose="Prove you are an adult from the EU but not from Scandinavia"
       scope="age-check"
       query={(queryBuilder) => queryBuilder.gte("age", 18).done()}
-      onResult={({ verified, result, uniqueIdentifier }) => {
-        if (verified) console.log(result, uniqueIdentifier)
+      onSuccess={({ proofs, result }) => {
+        // Verify the proofs on your backend with @zkpassport/sdk's verify()
+        fetch("/api/verify", { method: "POST", body: JSON.stringify({ proofs, result }) })
       }}
     />
   )
@@ -44,8 +45,8 @@ const handle = mount(document.getElementById("zk-passport")!, {
   purpose: "Prove you are an adult from the EU but not from Scandinavia",
   scope: "age-check",
   query: (queryBuilder) => queryBuilder.gte("age", 18).done(),
-  onResult: ({ verified, result, uniqueIdentifier }) => {
-    if (verified) console.log(result, uniqueIdentifier)
+  onSuccess: ({ proofs, result }) => {
+    fetch("/api/verify", { method: "POST", body: JSON.stringify({ proofs, result }) })
   },
 })
 
@@ -61,7 +62,7 @@ Opens the verification flow in a popup on the ZKPassport origin, where saved IDs
 ```tsx
 import { VerifyWithZKPassportButton } from "@zkpassport/ui/react-button"
 
-<VerifyWithZKPassportButton name="Aztec" scope="age-check" query={…} onResult={…} />
+<VerifyWithZKPassportButton name="Aztec" scope="age-check" query={…} onSuccess={…} />
 ```
 
 ```ts
@@ -96,11 +97,18 @@ All optional. The SDK lifecycle callbacks pass through verbatim — their signat
 | `onRequestReceived` | SDK | Mobile app received the request payload |
 | `onGeneratingProof` | SDK | User approved; proof generation started |
 | `onProofGenerated(proof)` | SDK | A single proof has been generated |
-| `onResult(response)` | SDK | Final result with `{ verified, uniqueIdentifier, result, ... }` — check `response.verified` for pass/fail |
+| `onSuccess({ proofs, result })` | SDK | Request completed and all proofs received — send them to your backend and verify them there |
+| `onResult(response)` | SDK | **Deprecated, card only** — use `onSuccess`. Final result with `{ verified, uniqueIdentifier, ... }`, verified via the ZKPassport verifier API |
 | `onReject` | SDK | User rejected on phone |
 | `onError(message)` | SDK | An SDK-side error (`message: string`) |
 
 > Internal failures (request build failed, the `query` callback threw, QR generation failed) are logged to the console and transition the card to the `error` visual state — they don't fire `onError`, which is reserved for SDK-emitted errors so its semantics match `@zkpassport/sdk` exactly.
+
+## Verifying the proofs
+
+The components do not verify proofs — a result checked in the browser can be tampered with before your app sees it. `onSuccess` hands you the proofs and the query result; send them to your backend and verify them there with `@zkpassport/sdk`'s `verify()` (see the SDK README). On success the card shows "Request complete".
+
+The card still supports the deprecated `onResult`, which verifies the proofs via the ZKPassport verifier API and drives the card's final screen from the `verified` flag. Treat that flag as UX only, never as proof of verification. The button has no `onResult`.
 
 ## Props
 

--- a/packages/zkpassport-ui/README.md
+++ b/packages/zkpassport-ui/README.md
@@ -1,6 +1,6 @@
 # ZKPassport UI
 
-Drop-in QR verification card for [ZKPassport](https://zkpassport.id). Mount once, get a verification flow with state transitions, retry, and result callbacks.
+Drop-in verification card and button for [ZKPassport](https://zkpassport.id). Mount once, get a verification flow with state transitions, retry, and result callbacks.
 
 ## Installation
 
@@ -21,9 +21,15 @@ export default function Page() {
       purpose="Prove you are an adult from the EU but not from Scandinavia"
       scope="age-check"
       query={(queryBuilder) => queryBuilder.gte("age", 18).done()}
-      onSuccess={({ proofs, result }) => {
-        // Verify the proofs on your backend with @zkpassport/sdk's verify()
-        fetch("/api/verify", { method: "POST", body: JSON.stringify({ proofs, result }) })
+      onSuccess={async ({ proofs, result }) => {
+        // Verify the proofs on your backend with @zkpassport/sdk's verify(),
+        // e.g. as part of creating the user's account
+        const res = await fetch("/api/register", {
+          method: "POST",
+          body: JSON.stringify({ proofs, result }),
+        })
+        // Returning false shows the card's error state instead of success
+        return (await res.json()).registered === true
       }}
     />
   )
@@ -45,8 +51,9 @@ const handle = mount(document.getElementById("zk-passport")!, {
   purpose: "Prove you are an adult from the EU but not from Scandinavia",
   scope: "age-check",
   query: (queryBuilder) => queryBuilder.gte("age", 18).done(),
-  onSuccess: ({ proofs, result }) => {
-    fetch("/api/verify", { method: "POST", body: JSON.stringify({ proofs, result }) })
+  onSuccess: async ({ proofs, result }) => {
+    const res = await fetch("/api/register", { method: "POST", body: JSON.stringify({ proofs, result }) })
+    return (await res.json()).registered === true
   },
 })
 
@@ -57,7 +64,7 @@ const handle = mount(document.getElementById("zk-passport")!, {
 
 ## Verify button
 
-Opens the verification flow in a popup on the ZKPassport origin, where saved IDs work across every relying party. Options are the card's, minus the QR-only ones, plus `label`, `theme` (`"light"` by default, `"auto"` to follow the OS), `classes`, `policyId` and `popupUrl`; progress and success show inside the button, and the only thing rendered outside it is the error message, which `showErrorMessage: false` turns off if you would rather report failures from `onError`; callbacks are the SDK's, plus `onClose` when the user closes the popup without a result.
+Opens the verification flow in a popup hosted by ZKPassport, where saved IDs work across every site. Options are the card's, minus the QR-only ones, plus `label`, `size`, `theme` (`"light"` by default, `"auto"` to follow the OS), `classes`, `policyId` and `popupUrl`. Progress and success show inside the button; the only thing rendered outside it is the error message, which `showErrorMessage: false` turns off if you would rather use `onError`. Callbacks are the SDK's, plus `onClose` when the user closes the popup without a result.
 
 ```tsx
 import { VerifyWithZKPassportButton } from "@zkpassport/ui/react-button"
@@ -97,16 +104,21 @@ All optional. The SDK lifecycle callbacks pass through verbatim — their signat
 | `onRequestReceived` | SDK | Mobile app received the request payload |
 | `onGeneratingProof` | SDK | User approved; proof generation started |
 | `onProofGenerated(proof)` | SDK | A single proof has been generated |
-| `onSuccess({ proofs, result })` | SDK | Request completed and all proofs received — send them to your backend and verify them there |
+| `onSuccess({ proofs, result })` | SDK | Request completed and all proofs received — verify them on your backend; return `false` (or throw) to show the error state instead of success (see [Verifying the proofs](#verifying-the-proofs)) |
 | `onResult(response)` | SDK | **Deprecated, card only** — use `onSuccess`. Final result with `{ verified, uniqueIdentifier, ... }`, verified via the ZKPassport verifier API |
 | `onReject` | SDK | User rejected on phone |
 | `onError(message)` | SDK | An SDK-side error (`message: string`) |
+| `onClose` | UI | **Button only** — user closed the popup before a result |
 
 > Internal failures (request build failed, the `query` callback threw, QR generation failed) are logged to the console and transition the card to the `error` visual state — they don't fire `onError`, which is reserved for SDK-emitted errors so its semantics match `@zkpassport/sdk` exactly.
 
 ## Verifying the proofs
 
-The components do not verify proofs — a result checked in the browser can be tampered with before your app sees it. `onSuccess` hands you the proofs and the query result; send them to your backend and verify them there with `@zkpassport/sdk`'s `verify()` (see the SDK README). On success the card shows "Request complete".
+The components do not verify proofs — a result checked in the browser can be tampered with before your app sees it. `onSuccess` hands you the proofs and the query result; send them to your backend and verify them there with `@zkpassport/sdk`'s `verify()` (see the SDK README), typically as part of a real operation like creating the user's account.
+
+The success state waits for your `onSuccess` handler, which decides what "success" means: return `false` (or throw) when your backend rejects the request and the component shows the error state instead; return anything else — or nothing — and it shows success once your handler completes.
+
+`verify()` also returns a `uniqueIdentifier` — the same for the same ID, domain and scope — which is what you store as the user's key (see the SDK README).
 
 The card still supports the deprecated `onResult`, which verifies the proofs via the ZKPassport verifier API and drives the card's final screen from the `verified` flag. Treat that flag as UX only, never as proof of verification. The button has no `onResult`.
 

--- a/packages/zkpassport-ui/src/button.css
+++ b/packages/zkpassport-ui/src/button.css
@@ -1,8 +1,8 @@
 @layer zkpassport {
   /* "Verify with ZKPassport" button (opens the hosted popup).
      Customize via CSS custom properties on the mount element or any ancestor:
-     --zkp-btn-bg/-fg/-border/-radius/-padding/-font/-font-size/-letter-spacing/
-     -text-transform, and --zkp-verify-success/-error for the verified and failed states.
+     --zkp-btn-bg/-fg/-border-color/-radius/-padding/-font/-font-size/-letter-spacing/
+     -text-transform, and --zkp-btn-success/-error for the verified and failed states.
      Sizing hangs off --zkp-btn-font-size: the icon, gap and padding are all in em.
 
      !important throughout: host resets (e.g. Tailwind preflight) are unlayered
@@ -10,6 +10,7 @@
   .zkp-verify-button {
     --zkp-bg: #ffffff;
     --zkp-brand: #2139a3;
+    --zkp-border: #d3d9e8;
     appearance: none !important;
     -webkit-appearance: none !important;
     -webkit-tap-highlight-color: transparent !important;
@@ -17,7 +18,7 @@
     align-items: center !important;
     justify-content: center !important;
     padding: var(--zkp-btn-padding, 0.8667em 1.6em) !important;
-    border: 1px solid var(--zkp-btn-border, #d3d9e8) !important;
+    border: 1px solid var(--zkp-btn-border-color, var(--zkp-border)) !important;
     border-radius: var(--zkp-btn-radius, 8px) !important;
     background: var(--zkp-btn-bg, var(--zkp-bg)) !important;
     color: var(--zkp-btn-fg, var(--zkp-brand)) !important;
@@ -42,13 +43,13 @@
   .zkp-verify-wrap[data-theme="dark"] .zkp-verify-button {
     --zkp-bg: #0f172a;
     --zkp-brand: #93b0f5;
-    --zkp-btn-border: #334155;
+    --zkp-border: #334155;
   }
   @media (prefers-color-scheme: dark) {
     .zkp-verify-wrap[data-theme="auto"] .zkp-verify-button {
       --zkp-bg: #0f172a;
       --zkp-brand: #93b0f5;
-      --zkp-btn-border: #334155;
+      --zkp-border: #334155;
     }
   }
   .zkp-verify-button:hover:not(:disabled) {
@@ -104,17 +105,17 @@
     flex-direction: column;
     align-items: center;
     gap: 8px;
-    --zkp-verify-success: #15803d;
-    --zkp-verify-error: #dc2626;
+    --zkp-success: #15803d;
+    --zkp-error: #dc2626;
   }
   .zkp-verify-wrap[data-theme="dark"] {
-    --zkp-verify-success: #4ade80;
-    --zkp-verify-error: #f87171;
+    --zkp-success: #4ade80;
+    --zkp-error: #f87171;
   }
   @media (prefers-color-scheme: dark) {
     .zkp-verify-wrap[data-theme="auto"] {
-      --zkp-verify-success: #4ade80;
-      --zkp-verify-error: #f87171;
+      --zkp-success: #4ade80;
+      --zkp-error: #f87171;
     }
   }
   .zkp-verify-error {
@@ -122,7 +123,7 @@
     font-family: ui-sans-serif, system-ui, sans-serif !important;
     font-size: 12.5px !important;
     line-height: 1.4 !important;
-    color: var(--zkp-verify-error) !important;
+    color: var(--zkp-btn-error, var(--zkp-error)) !important;
   }
   .zkp-verify-button:disabled {
     cursor: default !important;
@@ -134,7 +135,7 @@
     filter: saturate(0.75) !important;
   }
   .zkp-verify-button[data-status="success"] {
-    color: var(--zkp-verify-success) !important;
+    color: var(--zkp-btn-success, var(--zkp-success)) !important;
   }
 
   @keyframes zkp-spinner-rotate {

--- a/packages/zkpassport-ui/src/button/index.ts
+++ b/packages/zkpassport-ui/src/button/index.ts
@@ -110,7 +110,7 @@ export type { VerifyButtonSize, VerifyWithZKPassportButtonOptions } from "../ver
 export {
   openVerificationPopup,
   type PopupRequestConfig,
-  type PopupResult,
+  type PopupSuccess,
   type VerificationPopupHandle,
 } from "@zkpassport/sdk/popup"
 export { createOfflineQuery } from "@zkpassport/sdk/query"

--- a/packages/zkpassport-ui/src/card.tsx
+++ b/packages/zkpassport-ui/src/card.tsx
@@ -304,7 +304,8 @@ function getOverlayCaption(state: CardState): string {
     case "generating":
       return "Generating proof…"
     case "success":
-      return "Verification complete"
+      // Kept neutral: the card may not have verified anything. Final wording TBD.
+      return "Request complete"
     case "error":
       return "Something went wrong"
     default:

--- a/packages/zkpassport-ui/src/types.ts
+++ b/packages/zkpassport-ui/src/types.ts
@@ -38,6 +38,10 @@ export type ZKPassportQRCodeOptions = SdkRequestProps & {
   onRequestReceived?: SdkCallback<"onRequestReceived">
   onGeneratingProof?: SdkCallback<"onGeneratingProof">
   onProofGenerated?: SdkCallback<"onProofGenerated">
+  /**
+   * All proofs arrived (not verified yet — verify them on your backend).
+   * The component waits for this callback: return `false` (or throw) to show the error state.
+   */
   onSuccess?: SdkCallback<"onSuccess">
   /** @deprecated Use `onSuccess` and verify the proofs on your backend. */
   onResult?: SdkCallback<"onResult">

--- a/packages/zkpassport-ui/src/types.ts
+++ b/packages/zkpassport-ui/src/types.ts
@@ -8,7 +8,12 @@ type SdkCallback<K extends keyof QueryBuilderResult> = QueryBuilderResult[K] ext
 
 type SdkRequestProps = Omit<
   Parameters<ZKPassport["request"]>[0],
-  "projectID" | "topicOverride" | "keyPairOverride" | "cloudProverUrl" | "bridgeUrl"
+  | "projectID"
+  | "topicOverride"
+  | "keyPairOverride"
+  | "cloudProverUrl"
+  | "bridgeUrl"
+  | "verifierMode"
 >
 
 // Toggles for optional card sections. Each defaults to shown; set false to hide.
@@ -33,6 +38,8 @@ export type ZKPassportQRCodeOptions = SdkRequestProps & {
   onRequestReceived?: SdkCallback<"onRequestReceived">
   onGeneratingProof?: SdkCallback<"onGeneratingProof">
   onProofGenerated?: SdkCallback<"onProofGenerated">
+  onSuccess?: SdkCallback<"onSuccess">
+  /** @deprecated Use `onSuccess` and verify the proofs on your backend. */
   onResult?: SdkCallback<"onResult">
   onReject?: SdkCallback<"onReject">
   onError?: SdkCallback<"onError">

--- a/packages/zkpassport-ui/src/use-card.ts
+++ b/packages/zkpassport-ui/src/use-card.ts
@@ -88,7 +88,8 @@ export function useCard(options: ZKPassportQRCodeOptions): UseCard {
       onRequestReceived: _onRequestReceived,
       onGeneratingProof: _onGeneratingProof,
       onProofGenerated: _onProofGenerated,
-      onResult: _onResult,
+      onSuccess: _onSuccess,
+      onResult,
       onReject: _onReject,
       onError: _onError,
       ...sdkRequestArgs
@@ -127,7 +128,7 @@ export function useCard(options: ZKPassportQRCodeOptions): UseCard {
     }
 
     sdkRef
-      .current!.request({ ...sdkRequestArgs })
+      .current!.request({ ...sdkRequestArgs, verifierMode: "api" })
       .then((queryBuilder) => {
         if (cancelled) return
         let request: QueryBuilderResult
@@ -169,13 +170,26 @@ export function useCard(options: ZKPassportQRCodeOptions): UseCard {
             safeCall(optionsRef.current.onProofGenerated, proof)
           }),
         )
-        request.onResult(
+        request.onSuccess(
           guard((response) => {
-            introActiveRef.current = false
-            setState(response.verified ? "success" : "error")
-            safeCall(optionsRef.current.onResult, response)
+            if (!onResult) {
+              introActiveRef.current = false
+              setState("success")
+            }
+            safeCall(optionsRef.current.onSuccess, response)
           }),
         )
+        // The deprecated onResult drives the screens like before, with the
+        // verified flag coming from the ZKPassport verifier API
+        if (onResult) {
+          request.onResult(
+            guard((response) => {
+              introActiveRef.current = false
+              setState(response.verified ? "success" : "error")
+              safeCall(optionsRef.current.onResult, response)
+            }),
+          )
+        }
         request.onReject(
           guard(() => {
             introActiveRef.current = false

--- a/packages/zkpassport-ui/src/use-card.ts
+++ b/packages/zkpassport-ui/src/use-card.ts
@@ -95,6 +95,10 @@ export function useCard(options: ZKPassportQRCodeOptions): UseCard {
       ...sdkRequestArgs
     } = optionsRef.current
 
+    if (onResult && optionsRef.current.onSuccess) {
+      logger.warn("onResult is deprecated and drives the card; onSuccess return values are ignored")
+    }
+
     const fireReady = () => {
       if (readyFired) return
       readyFired = true
@@ -172,11 +176,32 @@ export function useCard(options: ZKPassportQRCodeOptions): UseCard {
         )
         request.onSuccess(
           guard((response) => {
-            if (!onResult) {
-              introActiveRef.current = false
-              setState("success")
+            if (onResult) {
+              safeCall(optionsRef.current.onSuccess, response)
+              return
             }
-            safeCall(optionsRef.current.onSuccess, response)
+            // Success waits for the app's onSuccess handler, which can veto it by
+            // returning false (e.g. when its backend did not verify the proofs)
+            const finish = (next: "success" | "error") => {
+              if (cancelled) return
+              introActiveRef.current = false
+              setState(next)
+            }
+            let verdict: unknown
+            try {
+              verdict = optionsRef.current.onSuccess?.(response)
+            } catch (reason) {
+              logger.error(reason)
+              finish("error")
+              return
+            }
+            Promise.resolve(verdict).then(
+              (value) => finish(value === false ? "error" : "success"),
+              (reason) => {
+                logger.error(reason)
+                finish("error")
+              },
+            )
           }),
         )
         // The deprecated onResult drives the screens like before, with the

--- a/packages/zkpassport-ui/src/verification.ts
+++ b/packages/zkpassport-ui/src/verification.ts
@@ -56,6 +56,9 @@ export function createVerification(
 ): VerificationController {
   let state: VerificationState = { status: "idle", error: null }
   let popupHandle: VerificationPopupHandle | null = null
+  // Numbers each verify() so a slow onSuccess from an old popup
+  // can't overwrite the status of a newer one
+  let latestAttempt = 0
 
   const setStatus = (status: VerificationStatus, error: string | null = null) => {
     state = { status, error }
@@ -75,6 +78,7 @@ export function createVerification(
       popupHandle = null
     }
 
+    const thisAttempt = ++latestAttempt
     let query: Query
     try {
       query = buildQuery(options)
@@ -95,9 +99,27 @@ export function createVerification(
         onRequestReceived: () => getOptions().onRequestReceived?.(),
         onGeneratingProof: () => getOptions().onGeneratingProof?.(),
         onProofGenerated: (progress) => getOptions().onProofGenerated?.(progress),
+        // Success waits for the app's onSuccess handler, which can veto it by
+        // returning false (e.g. when its backend did not verify the proofs)
         onSuccess: (response) => {
-          setStatus("success")
-          getOptions().onSuccess?.(response)
+          const finish = (next: "success" | "error") => {
+            if (latestAttempt === thisAttempt) setStatus(next)
+          }
+          let verdict: unknown
+          try {
+            verdict = getOptions().onSuccess?.(response)
+          } catch (reason) {
+            logger.error(reason)
+            finish("error")
+            return
+          }
+          Promise.resolve(verdict).then(
+            (value) => finish(value === false ? "error" : "success"),
+            (reason) => {
+              logger.error(reason)
+              finish("error")
+            },
+          )
         },
         onReject: () => {
           setStatus("error")
@@ -122,6 +144,7 @@ export function createVerification(
   }
 
   const close = () => {
+    latestAttempt++
     popupHandle?.close()
     popupHandle = null
   }

--- a/packages/zkpassport-ui/src/verification.ts
+++ b/packages/zkpassport-ui/src/verification.ts
@@ -95,9 +95,9 @@ export function createVerification(
         onRequestReceived: () => getOptions().onRequestReceived?.(),
         onGeneratingProof: () => getOptions().onGeneratingProof?.(),
         onProofGenerated: (progress) => getOptions().onProofGenerated?.(progress),
-        onResult: (result) => {
-          setStatus(result.verified ? "success" : "error")
-          getOptions().onResult?.(result)
+        onSuccess: (response) => {
+          setStatus("success")
+          getOptions().onSuccess?.(response)
         },
         onReject: () => {
           setStatus("error")

--- a/packages/zkpassport-ui/tests/verification.test.ts
+++ b/packages/zkpassport-ui/tests/verification.test.ts
@@ -76,7 +76,7 @@ describe("createVerification", () => {
     expect(configure.query).toEqual({ policy: "pol_123" })
   })
 
-  test("relays success to onSuccess and reports the popup as done", () => {
+  test("relays success to onSuccess and waits for it before reporting success", async () => {
     const { emitFromPopup } = setupFakeWindow()
     const statuses: string[] = []
     const received: unknown[] = []
@@ -84,7 +84,9 @@ describe("createVerification", () => {
       () => ({
         name: "Aztec",
         query: (builder) => builder.done(),
-        onSuccess: (response) => received.push(response),
+        onSuccess: async (response) => {
+          received.push(response)
+        },
       }),
       (state) => statuses.push(state.status),
     )
@@ -92,9 +94,31 @@ describe("createVerification", () => {
     verification.verify()
     emitFromPopup({ zkpassport: true, type: "ready" })
     emitFromPopup({ zkpassport: true, type: "success", proofs: [{ proof: "0x1" }], result: {} })
+    expect(statuses).toEqual(["in-progress"])
+    await new Promise((resolve) => setTimeout(resolve, 0))
 
     expect(received).toEqual([{ proofs: [{ proof: "0x1" }], result: {} }])
     expect(statuses).toEqual(["in-progress", "success"])
+  })
+
+  test("shows the error status when onSuccess vetoes by returning false", async () => {
+    const { emitFromPopup } = setupFakeWindow()
+    const statuses: string[] = []
+    const verification = createVerification(
+      () => ({
+        name: "Aztec",
+        query: (builder) => builder.done(),
+        onSuccess: async () => false,
+      }),
+      (state) => statuses.push(state.status),
+    )
+
+    verification.verify()
+    emitFromPopup({ zkpassport: true, type: "ready" })
+    emitFromPopup({ zkpassport: true, type: "success", proofs: [], result: {} })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(statuses).toEqual(["in-progress", "error"])
   })
 
   test("reports an error status when the user rejects the request", () => {
@@ -136,7 +160,9 @@ describe("createVerification", () => {
     let options: VerificationOptions = {
       name: "Aztec",
       query: (builder) => builder.done(),
-      onSuccess: () => received.push("click-time"),
+      onSuccess: () => {
+        received.push("click-time")
+      },
     }
     const verification = createVerification(
       () => options,
@@ -145,7 +171,12 @@ describe("createVerification", () => {
 
     verification.verify()
     // The consumer re-renders with a new callback while the popup works
-    options = { ...options, onSuccess: () => received.push("event-time") }
+    options = {
+      ...options,
+      onSuccess: () => {
+        received.push("event-time")
+      },
+    }
     emitFromPopup({ zkpassport: true, type: "ready" })
     emitFromPopup({ zkpassport: true, type: "success", proofs: [], result: {} })
 

--- a/packages/zkpassport-ui/tests/verification.test.ts
+++ b/packages/zkpassport-ui/tests/verification.test.ts
@@ -60,7 +60,7 @@ describe("createVerification", () => {
       policyId: "pol_123",
       label: "Get verified",
       classes: { button: "my-button" },
-      onResult: () => {},
+      onSuccess: () => {},
       query: (builder) => builder.done(),
     }
 
@@ -76,7 +76,28 @@ describe("createVerification", () => {
     expect(configure.query).toEqual({ policy: "pol_123" })
   })
 
-  test("tracks the popup outcome", () => {
+  test("relays success to onSuccess and reports the popup as done", () => {
+    const { emitFromPopup } = setupFakeWindow()
+    const statuses: string[] = []
+    const received: unknown[] = []
+    const verification = createVerification(
+      () => ({
+        name: "Aztec",
+        query: (builder) => builder.done(),
+        onSuccess: (response) => received.push(response),
+      }),
+      (state) => statuses.push(state.status),
+    )
+
+    verification.verify()
+    emitFromPopup({ zkpassport: true, type: "ready" })
+    emitFromPopup({ zkpassport: true, type: "success", proofs: [{ proof: "0x1" }], result: {} })
+
+    expect(received).toEqual([{ proofs: [{ proof: "0x1" }], result: {} }])
+    expect(statuses).toEqual(["in-progress", "success"])
+  })
+
+  test("reports an error status when the user rejects the request", () => {
     const { emitFromPopup } = setupFakeWindow()
     const statuses: string[] = []
     const verification = createVerification(
@@ -85,16 +106,9 @@ describe("createVerification", () => {
     )
 
     verification.verify()
-    emitFromPopup({
-      zkpassport: true,
-      type: "result",
-      proofs: [],
-      result: {},
-      uniqueIdentifier: "0x1",
-      verified: true,
-    })
+    emitFromPopup({ zkpassport: true, type: "rejected" })
 
-    expect(statuses).toEqual(["in-progress", "success"])
+    expect(statuses).toEqual(["in-progress", "error"])
   })
 
   test("disposes a stale popup handle before reopening", async () => {
@@ -122,7 +136,7 @@ describe("createVerification", () => {
     let options: VerificationOptions = {
       name: "Aztec",
       query: (builder) => builder.done(),
-      onResult: () => received.push("click-time"),
+      onSuccess: () => received.push("click-time"),
     }
     const verification = createVerification(
       () => options,
@@ -131,16 +145,9 @@ describe("createVerification", () => {
 
     verification.verify()
     // The consumer re-renders with a new callback while the popup works
-    options = { ...options, onResult: () => received.push("event-time") }
+    options = { ...options, onSuccess: () => received.push("event-time") }
     emitFromPopup({ zkpassport: true, type: "ready" })
-    emitFromPopup({
-      zkpassport: true,
-      type: "result",
-      proofs: [],
-      result: {},
-      uniqueIdentifier: "0x1",
-      verified: true,
-    })
+    emitFromPopup({ zkpassport: true, type: "success", proofs: [], result: {} })
 
     expect(received).toEqual(["event-time"])
   })


### PR DESCRIPTION
A verification result can be tampered with in the user's browser, so apps must verify the proofs on their own server.

### Key changes
- New `onSuccess` hands the app the proofs and result to verify on its backend
- `onResult` is deprecated; its verified flag now comes from the ZKPassport verifier API
- The verify button and the hosted popup perform no verification at all

### Related PRs
- #241 (base branch)
- #247

### Rollout order
Deploy the verifier API (`/verify`, zkpassport/zkpassport-proof-verifier#3) before releasing — the card's deprecated `onResult` verifies only through it.