### PR TITLE
feat(sdk): Drop the policy version from the request scope

### DIFF
--- a/packages/zkpassport-sdk/src/index.ts
+++ b/packages/zkpassport-sdk/src/index.ts
@@ -59,10 +59,6 @@ if (typeof globalThis.Buffer === "undefined") {
   }
 }
 
-function policyScope(policy: { id: string; version: number }): string {
-  return `${policy.id}:${policy.version}`
-}
-
 const DEFAULT_PURPOSE = "Verify identity privately"
 
 export {
@@ -129,10 +125,7 @@ export class ZKPassport {
   private topicToProofs: Record<string, Array<ProofResult>> = {}
   private topicToFailedProofCount: Record<string, number> = {}
   private topicToResults: Record<string, QueryResult> = {}
-  private topicToPolicy: Record<
-    string,
-    { id: string; version: number; proofStorageEnabled: boolean }
-  > = {}
+  private topicToPolicy: Record<string, { id: string; proofStorageEnabled: boolean }> = {}
   private dashboardConfig: DashboardConfig | null = null
   private dashboardConfigPromise: Promise<DashboardConfig | null> | null = null
   private dashboardConfigError: Error | null = null
@@ -500,11 +493,10 @@ export class ZKPassport {
           if (!this.topicToCallerPurpose[topic]) {
             svc.purpose = policy.purpose || DEFAULT_PURPOSE
           }
-          svc.scope = policyScope(policy)
+          svc.scope = policy.id
         }
         this.topicToPolicy[topic] = {
           id: policy.id,
-          version: policy.version,
           proofStorageEnabled: policy.proofStorageEnabled === true,
         }
         return this.getZkPassportRequest(topic)
@@ -631,11 +623,6 @@ export class ZKPassport {
         `Policy '${policyId}' not found for domain '${this.domain}'. The dashboard returned ${config.policies.length} policies for this domain.`,
       )
     }
-    if (!Number.isInteger(policy.version) || policy.version < 1) {
-      throw new Error(
-        `Invalid policy '${policyId}' for domain '${this.domain}': version must be a positive integer (got ${JSON.stringify(policy.version)}).`,
-      )
-    }
     if (!policy.query || typeof policy.query !== "object") {
       throw new Error(
         `Invalid policy '${policyId}' for domain '${this.domain}': missing query object.`,
@@ -666,7 +653,7 @@ export class ZKPassport {
    * @param name Your service name. Defaults to the dashboard branding, then the domain.
    * @param logo Your service logo. Defaults to the dashboard branding.
    * @param purpose Explanation shown to the user. Defaults to the policy's purpose (if any), then a generic message.
-   * @param scope Use-case scope (drives the nullifier). Defaults to the domain. Locked by `.policy()` (to `<id>:<version>`).
+   * @param scope Use-case scope (drives the nullifier). Defaults to the domain. Locked by `.policy()` (to the policy id).
    * @param projectID The project ID of your service
    * @param validity How many seconds ago the proof checking the expiry date of the ID should have been generated
    * @param mode The proof mode (e.g. "fast" / "compressed").

--- a/packages/zkpassport-sdk/src/types.ts
+++ b/packages/zkpassport-sdk/src/types.ts
@@ -83,7 +83,6 @@ export type SolidityVerifierParameters = {
 
 export type Policy = {
   id: string
-  version: number
   name: string
   purpose: string
   projectId: string | null

--- a/packages/zkpassport-sdk/tests/proof-submission.test.ts
+++ b/packages/zkpassport-sdk/tests/proof-submission.test.ts
@@ -28,14 +28,12 @@ describe("Proof submission", () => {
       topic?: string
       failedProofs?: number
       // Defaults to a storage-enabled policy; pass null to simulate a self-serve request.
-      policy?: { id: string; version: number; proofStorageEnabled: boolean } | null
+      policy?: { id: string; proofStorageEnabled: boolean } | null
     } = {},
   ) {
     const topic = opts.topic ?? "topic-1"
     const policy =
-      opts.policy === undefined
-        ? { id: "pol_xyz", version: 3, proofStorageEnabled: true }
-        : opts.policy
+      opts.policy === undefined ? { id: "pol_xyz", proofStorageEnabled: true } : opts.policy
     const proof = {
       proof: "0xdeadbeef",
       vkeyHash: "0x1",
@@ -50,7 +48,7 @@ describe("Proof submission", () => {
     i.topicToResults[topic] = { age: { gte: 18 } }
     i.topicToConfig[topic] = { age: { gte: 18 } }
     i.topicToLocalConfig[topic] = { validity: 0, devMode: false, oprfKeyId: null }
-    const scope = policy ? `${policy.id}:${policy.version}` : "test-scope"
+    const scope = policy ? policy.id : "test-scope"
     i.topicToService[topic] = { name: "n", logo: "l", purpose: "p", scope }
     if (policy) i.topicToPolicy[topic] = policy
     i.topicToPublicKey[topic] = "04deadbeefpubkey"
@@ -80,7 +78,7 @@ describe("Proof submission", () => {
     const body = JSON.parse(fetchedBodies[0])
     expect(body).toMatchObject({
       domain: "localhost",
-      scope: "pol_xyz:3",
+      scope: "pol_xyz",
       query: { age: { gte: 18 } },
       // The bridge public key (URL `p=`), not the topic — links the proof to its activity row.
       requestId: "04deadbeefpubkey",
@@ -102,7 +100,7 @@ describe("Proof submission", () => {
   test("does not submit when the policy has proof storage disabled", async () => {
     const zk = new ZKPassport("localhost")
     const { topic } = primeForHandleResult(zk, {
-      policy: { id: "pol_xyz", version: 3, proofStorageEnabled: false },
+      policy: { id: "pol_xyz", proofStorageEnabled: false },
     })
 
     await (zk as any).handleResult(topic)

--- a/packages/zkpassport-sdk/tests/query-builder.test.ts
+++ b/packages/zkpassport-sdk/tests/query-builder.test.ts
@@ -548,7 +548,7 @@ describe("Policy-driven requests", () => {
       name: "Dashboard Brand",
       logo: "https://dashboard.example/logo.png",
       purpose: "Policy purpose",
-      scope: "pol_xyz:3",
+      scope: "pol_xyz",
     })
   })
 
@@ -574,7 +574,7 @@ describe("Policy-driven requests", () => {
     expect(service.logo).toBe("https://white.example/logo.png")
     // purpose/scope are locked by the policy
     expect(service.purpose).toBe("Policy purpose")
-    expect(service.scope).toBe("pol_xyz:3")
+    expect(service.scope).toBe("pol_xyz")
   })
 
   test("policy locks scope but caller's purpose still wins", async () => {
@@ -591,7 +591,7 @@ describe("Policy-driven requests", () => {
     const servicePart = new URL(result.url).searchParams.get("s")!
     const service = JSON.parse(Buffer.from(servicePart, "base64").toString())
     expect(service.purpose).toBe("Caller-supplied purpose")
-    expect(service.scope).toBe("pol_xyz:3")
+    expect(service.scope).toBe("pol_xyz")
   })
 
   test("self-serve callers get sensible defaults when no fields are supplied", async () => {
@@ -679,32 +679,6 @@ describe("Policy-driven requests", () => {
     expect(() => builder.policy("")).toThrow(/non-empty string/)
   })
 
-  test(".policy() rejects a policy with an invalid version", async () => {
-    for (const version of [0, -1]) {
-      mockFetchReturning({
-        project: {
-          name: "Brand",
-          domain: "localhost",
-          logoUrl: "https://e/l.png",
-          allowedOrigins: [],
-        },
-        policies: [
-          {
-            id: "pol_x",
-            version,
-            name: "x",
-            purpose: "",
-            projectId: null,
-            query: { age: { gte: 18 } },
-          },
-        ],
-      })
-      const zk = new ZkPassportVerifier("localhost")
-      const builder = await zk.request({})
-      expect(() => builder.policy("pol_x")).toThrow(/Invalid policy/)
-    }
-  })
-
   test("policy with empty branding falls back to defaults (domain / generic purpose)", async () => {
     mockFetchReturning({
       project: { name: "", domain: "localhost", logoUrl: null, allowedOrigins: [] },
@@ -727,7 +701,7 @@ describe("Policy-driven requests", () => {
     expect(service.name).toBe("localhost")
     expect(service.logo).toBe("")
     expect(service.purpose).toBe("Verify identity privately")
-    expect(service.scope).toBe("pol_blank:1")
+    expect(service.scope).toBe("pol_blank")
   })
 
   test("self-serve callers benefit from dashboard branding when the domain is registered", async () => {


### PR DESCRIPTION
The dashboard no longer versions policies, so the SDK's policy scope drops the version suffix.

### Key changes
- `.policy()` locks the scope to the policy id (was `<id>:<version>`)
- The `Policy` type no longer has a `version` field
- The scope drives the user's unique identifier, so returning users get a new identifier once after upgrading

### Deployment order
Publish only after the dashboard change below is live; it accepts both scope forms.

### Related PRs
- zkpassport/zkpassport-customer-dashboard#254