### PR TITLE
fix(utils): Normalize German country code in disclosed data

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -84,7 +84,7 @@
     },
     "packages/zkpassport-sdk": {
       "name": "@zkpassport/sdk",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "dependencies": {
         "@aztec/bb.js": "5.0.0",
         "@aztec/bb.js-v4": "npm:@aztec/bb.js@4.2.0-aztecnr-rc.2",
@@ -111,7 +111,7 @@
     },
     "packages/zkpassport-ui": {
       "name": "@zkpassport/ui",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "dependencies": {
         "@zkpassport/sdk": "workspace:*",
         "qrcode": "^1.5.4",
@@ -136,7 +136,7 @@
     },
     "packages/zkpassport-utils": {
       "name": "@zkpassport/utils",
-      "version": "0.37.3",
+      "version": "0.37.5",
       "dependencies": {
         "@lapo/asn1js": "^2.0.4",
         "@noble/ciphers": "^1.0.0",

--- a/packages/zkpassport-sdk/package.json
+++ b/packages/zkpassport-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkpassport/sdk",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "Privacy-preserving identity verification using passports and ID cards",
   "author": "ZKPassport",
   "license": "Apache-2.0",

--- a/packages/zkpassport-sdk/src/constants.ts
+++ b/packages/zkpassport-sdk/src/constants.ts
@@ -1,4 +1,4 @@
-export const VERSION = "0.16.1"
+export const VERSION = "0.16.2"
 export const DEFAULT_VALIDITY = 7 * 24 * 60 * 60 // 7 days
 export const DEFAULT_DATE_VALUE = new Date(0)
 

--- a/packages/zkpassport-sdk/tests/public-input-checker.test.ts
+++ b/packages/zkpassport-sdk/tests/public-input-checker.test.ts
@@ -2946,3 +2946,104 @@ describe("PublicInputChecker - query completeness", () => {
     expect(queryResultErrors.sanctions?.commitment?.message).toContain("sanctions exclusion")
   })
 })
+
+// Reported by a user with a German passport: the app normalizes the MRZ code "D<<" to "DEU" in the
+// query result, so the disclosed data parsed out of the proof has to be normalized the same way.
+describe("PublicInputChecker - German documents (D<< country code)", () => {
+  const germanPassportMRZ =
+    "P<D<<MUSTERMANN<<ERIKA<<<<<<<<<<<<<<<<<<<<<<C01X00T478D<<6408125F2702283<<<<<<<<<<<<<<<4"
+  const germanIDCardMRZ =
+    "IDD<<L01X00T471<<<<<<<<<<<<<<<6408125F2702283D<<<<<<<<<<<<<4MUSTERMANN<<ERIKA<<<<<<<<<<<<<"
+
+  const proofFor = (mrz: string, ...ranges: [number, number][]) => {
+    const mask = new Array(90).fill(0)
+    for (const [start, end] of ranges) mask.fill(1, start, end)
+    return makeDiscloseProof(getDisclosedBytesFromMrzAndMask(mrz, mask))
+  }
+
+  describe("passports (TD3)", () => {
+    test("nationality disclose accepts DEU", () => {
+      const { queryResultErrors } = PublicInputChecker.checkDiscloseBytesPublicInputs(
+        proofFor(germanPassportMRZ, [54, 57]),
+        { nationality: { disclose: true } },
+        { nationality: { disclose: { result: "DEU" } } },
+      )
+      expect(queryResultErrors.nationality).toBeUndefined()
+    })
+
+    test("issuing_country disclose accepts DEU", () => {
+      const { queryResultErrors } = PublicInputChecker.checkDiscloseBytesPublicInputs(
+        proofFor(germanPassportMRZ, [2, 5]),
+        { issuing_country: { disclose: true } },
+        { issuing_country: { disclose: { result: "DEU" } } },
+      )
+      expect(queryResultErrors.issuing_country).toBeUndefined()
+    })
+
+    test("nationality eq accepts DEU", () => {
+      const { queryResultErrors } = PublicInputChecker.checkDiscloseBytesPublicInputs(
+        proofFor(germanPassportMRZ, [54, 57]),
+        { nationality: { eq: "DEU" } },
+        { nationality: { eq: { expected: "DEU", result: true } } },
+      )
+      expect(queryResultErrors.nationality).toBeUndefined()
+    })
+
+    test("issuing_country eq accepts DEU", () => {
+      const { queryResultErrors } = PublicInputChecker.checkDiscloseBytesPublicInputs(
+        proofFor(germanPassportMRZ, [2, 5]),
+        { issuing_country: { eq: "DEU" } },
+        { issuing_country: { eq: { expected: "DEU", result: true } } },
+      )
+      expect(queryResultErrors.issuing_country).toBeUndefined()
+    })
+
+    test("still rejects a nationality the passport does not hold", () => {
+      const { queryResultErrors } = PublicInputChecker.checkDiscloseBytesPublicInputs(
+        proofFor(germanPassportMRZ, [54, 57]),
+        { nationality: { disclose: true } },
+        { nationality: { disclose: { result: "FRA" } } },
+      )
+      expect(queryResultErrors.nationality?.disclose).toBeDefined()
+    })
+
+    test("the reported query passes end to end", () => {
+      const { isCorrect } = PublicInputChecker.checkDiscloseBytesPublicInputs(
+        proofFor(germanPassportMRZ, [5, 44], [54, 57], [57, 63]),
+        {
+          firstname: { disclose: true },
+          lastname: { disclose: true },
+          birthdate: { disclose: true },
+          nationality: { disclose: true },
+        },
+        {
+          firstname: { disclose: { result: "ERIKA" } },
+          lastname: { disclose: { result: "MUSTERMANN" } },
+          birthdate: { disclose: { result: new Date(Date.UTC(1964, 7, 12)) } },
+          nationality: { disclose: { result: "DEU" } },
+        },
+      )
+      expect(isCorrect).toBe(true)
+    })
+  })
+
+  describe("id cards (TD1)", () => {
+    test("nationality disclose accepts DEU", () => {
+      const { queryResultErrors } = PublicInputChecker.checkDiscloseBytesPublicInputs(
+        proofFor(germanIDCardMRZ, [45, 48]),
+        { nationality: { disclose: true } },
+        { nationality: { disclose: { result: "DEU" } } },
+      )
+      expect(queryResultErrors.nationality).toBeUndefined()
+    })
+
+    test("issuing_country disclose accepts DEU", () => {
+      const { queryResultErrors } = PublicInputChecker.checkDiscloseBytesPublicInputs(
+        proofFor(germanIDCardMRZ, [2, 5]),
+        { issuing_country: { disclose: true } },
+        { issuing_country: { disclose: { result: "DEU" } } },
+      )
+      expect(queryResultErrors.issuing_country).toBeUndefined()
+    })
+  })
+})

--- a/packages/zkpassport-sdk/tests/public-input-checker.test.ts
+++ b/packages/zkpassport-sdk/tests/public-input-checker.test.ts
@@ -2947,15 +2947,14 @@ describe("PublicInputChecker - query completeness", () => {
   })
 })
 
-// Reported by a user with a German passport: the app normalizes the MRZ code "D<<" to "DEU" in the
-// query result, so the disclosed data parsed out of the proof has to be normalized the same way.
+// The app reports "DEU" for the MRZ code "D<<", so the checker must parse it the same way
 describe("PublicInputChecker - German documents (D<< country code)", () => {
   const germanPassportMRZ =
     "P<D<<MUSTERMANN<<ERIKA<<<<<<<<<<<<<<<<<<<<<<C01X00T478D<<6408125F2702283<<<<<<<<<<<<<<<4"
   const germanIDCardMRZ =
     "IDD<<L01X00T471<<<<<<<<<<<<<<<6408125F2702283D<<<<<<<<<<<<<4MUSTERMANN<<ERIKA<<<<<<<<<<<<<"
 
-  const proofFor = (mrz: string, ...ranges: [number, number][]) => {
+  const makeDiscloseProofFromMrz = (mrz: string, ...ranges: [number, number][]) => {
     const mask = new Array(90).fill(0)
     for (const [start, end] of ranges) mask.fill(1, start, end)
     return makeDiscloseProof(getDisclosedBytesFromMrzAndMask(mrz, mask))
@@ -2964,7 +2963,7 @@ describe("PublicInputChecker - German documents (D<< country code)", () => {
   describe("passports (TD3)", () => {
     test("nationality disclose accepts DEU", () => {
       const { queryResultErrors } = PublicInputChecker.checkDiscloseBytesPublicInputs(
-        proofFor(germanPassportMRZ, [54, 57]),
+        makeDiscloseProofFromMrz(germanPassportMRZ, [54, 57]),
         { nationality: { disclose: true } },
         { nationality: { disclose: { result: "DEU" } } },
       )
@@ -2973,7 +2972,7 @@ describe("PublicInputChecker - German documents (D<< country code)", () => {
 
     test("issuing_country disclose accepts DEU", () => {
       const { queryResultErrors } = PublicInputChecker.checkDiscloseBytesPublicInputs(
-        proofFor(germanPassportMRZ, [2, 5]),
+        makeDiscloseProofFromMrz(germanPassportMRZ, [2, 5]),
         { issuing_country: { disclose: true } },
         { issuing_country: { disclose: { result: "DEU" } } },
       )
@@ -2982,7 +2981,7 @@ describe("PublicInputChecker - German documents (D<< country code)", () => {
 
     test("nationality eq accepts DEU", () => {
       const { queryResultErrors } = PublicInputChecker.checkDiscloseBytesPublicInputs(
-        proofFor(germanPassportMRZ, [54, 57]),
+        makeDiscloseProofFromMrz(germanPassportMRZ, [54, 57]),
         { nationality: { eq: "DEU" } },
         { nationality: { eq: { expected: "DEU", result: true } } },
       )
@@ -2991,7 +2990,7 @@ describe("PublicInputChecker - German documents (D<< country code)", () => {
 
     test("issuing_country eq accepts DEU", () => {
       const { queryResultErrors } = PublicInputChecker.checkDiscloseBytesPublicInputs(
-        proofFor(germanPassportMRZ, [2, 5]),
+        makeDiscloseProofFromMrz(germanPassportMRZ, [2, 5]),
         { issuing_country: { eq: "DEU" } },
         { issuing_country: { eq: { expected: "DEU", result: true } } },
       )
@@ -3000,7 +2999,7 @@ describe("PublicInputChecker - German documents (D<< country code)", () => {
 
     test("still rejects a nationality the passport does not hold", () => {
       const { queryResultErrors } = PublicInputChecker.checkDiscloseBytesPublicInputs(
-        proofFor(germanPassportMRZ, [54, 57]),
+        makeDiscloseProofFromMrz(germanPassportMRZ, [54, 57]),
         { nationality: { disclose: true } },
         { nationality: { disclose: { result: "FRA" } } },
       )
@@ -3009,7 +3008,7 @@ describe("PublicInputChecker - German documents (D<< country code)", () => {
 
     test("the reported query passes end to end", () => {
       const { isCorrect } = PublicInputChecker.checkDiscloseBytesPublicInputs(
-        proofFor(germanPassportMRZ, [5, 44], [54, 57], [57, 63]),
+        makeDiscloseProofFromMrz(germanPassportMRZ, [5, 44], [54, 57], [57, 63]),
         {
           firstname: { disclose: true },
           lastname: { disclose: true },
@@ -3030,7 +3029,7 @@ describe("PublicInputChecker - German documents (D<< country code)", () => {
   describe("id cards (TD1)", () => {
     test("nationality disclose accepts DEU", () => {
       const { queryResultErrors } = PublicInputChecker.checkDiscloseBytesPublicInputs(
-        proofFor(germanIDCardMRZ, [45, 48]),
+        makeDiscloseProofFromMrz(germanIDCardMRZ, [45, 48]),
         { nationality: { disclose: true } },
         { nationality: { disclose: { result: "DEU" } } },
       )
@@ -3039,7 +3038,7 @@ describe("PublicInputChecker - German documents (D<< country code)", () => {
 
     test("issuing_country disclose accepts DEU", () => {
       const { queryResultErrors } = PublicInputChecker.checkDiscloseBytesPublicInputs(
-        proofFor(germanIDCardMRZ, [2, 5]),
+        makeDiscloseProofFromMrz(germanIDCardMRZ, [2, 5]),
         { issuing_country: { disclose: true } },
         { issuing_country: { disclose: { result: "DEU" } } },
       )

--- a/packages/zkpassport-ui/package.json
+++ b/packages/zkpassport-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkpassport/ui",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "Drop-in QR verification card for ZKPassport. Vanilla JS by default; React component available at @zkpassport/ui/react.",
   "author": "ZKPassport",
   "license": "Apache-2.0",

--- a/packages/zkpassport-utils/package.json
+++ b/packages/zkpassport-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkpassport/utils",
-  "version": "0.37.3",
+  "version": "0.37.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/zkpassport/zkpassport-packages",

--- a/packages/zkpassport-utils/src/circuit-matcher.ts
+++ b/packages/zkpassport-utils/src/circuit-matcher.ts
@@ -26,7 +26,7 @@ import {
   getRSAPSSParams,
 } from "./cms/utils"
 import { DG1_INPUT_SIZE, E_CONTENT_INPUT_SIZE, SIGNED_ATTR_INPUT_SIZE } from "./constants"
-import { countryCodeAlpha2ToAlpha3 } from "./country/country"
+import { countryCodeAlpha2ToAlpha3, normalizeCountryCode } from "./country/country"
 import { computeMerkleProof } from "./merkle-tree"
 import {
   extractTBS,
@@ -200,7 +200,7 @@ function getCscaCandidates(
     }
   }
   const country = getDSCCountry(dsc)
-  const formattedCountry = country === "D<<" ? "DEU" : country
+  const formattedCountry = normalizeCountryCode(country)
 
   const checkAgainstAuthorityKeyIdentifier = (cert: PackagedCertificate) => {
     return (

--- a/packages/zkpassport-utils/src/circuits/disclose.ts
+++ b/packages/zkpassport-utils/src/circuits/disclose.ts
@@ -6,6 +6,7 @@ import {
   rightPadArrayWithZeros,
 } from "../utils"
 import { ProofData, ProofType, ProofTypeLength } from "."
+import { normalizeCountryCode } from "../country/country"
 import { poseidon2HashAsync } from "@zkpassport/poseidon2"
 import { sha256 } from "@noble/hashes/sha2.js"
 
@@ -157,8 +158,8 @@ export class DisclosedData {
     const fullName = givenNames + " " + lastName
 
     return new DisclosedData({
-      issuingCountry: decode(raw.issuingCountry),
-      nationality: decode(raw.nationality),
+      issuingCountry: normalizeCountryCode(decode(raw.issuingCountry)),
+      nationality: normalizeCountryCode(decode(raw.nationality)),
       documentType: parseDocumentType(decode(raw.documentType)),
       documentNumber: stripChevrons(decode(raw.documentNumber)),
       dateOfExpiry: parseDate(raw.dateOfExpiry),
@@ -200,8 +201,8 @@ export class DisclosedData {
     const fullName = givenNames + " " + lastName
 
     return new DisclosedData({
-      issuingCountry: decode(raw.issuingCountry),
-      nationality: decode(raw.nationality),
+      issuingCountry: normalizeCountryCode(decode(raw.issuingCountry)),
+      nationality: normalizeCountryCode(decode(raw.nationality)),
       documentType: parseDocumentType(decode(raw.documentType)),
       documentNumber: stripChevrons(decode(raw.documentNumber)),
       dateOfExpiry: parseDate(raw.dateOfExpiry),
@@ -259,8 +260,8 @@ export class DisclosedData {
     const fullName = givenNames + " " + lastName
 
     return new DisclosedData({
-      issuingCountry: decode(raw.issuingCountry),
-      nationality: decode(raw.nationality),
+      issuingCountry: normalizeCountryCode(decode(raw.issuingCountry)),
+      nationality: normalizeCountryCode(decode(raw.nationality)),
       documentType: parseDocumentType(decode(raw.documentType)),
       documentNumber: stripChevrons(decode(raw.documentNumber)),
       dateOfExpiry: parseDate(raw.dateOfExpiry),

--- a/packages/zkpassport-utils/src/country/country.ts
+++ b/packages/zkpassport-utils/src/country/country.ts
@@ -1,4 +1,5 @@
-// Germany uses "D<<" in the MRZ instead of its ISO alpha-3 code
+// Germany is the only country whose MRZ code is not its ISO alpha-3 code:
+// ICAO Doc 9303 lets it use the historic "D" padded with "<" filler
 export function normalizeCountryCode(countryCode: string) {
   return countryCode === "D<<" ? "DEU" : countryCode
 }

--- a/packages/zkpassport-utils/src/country/country.ts
+++ b/packages/zkpassport-utils/src/country/country.ts
@@ -1,3 +1,8 @@
+// Germany uses "D<<" in the MRZ instead of its ISO alpha-3 code
+export function normalizeCountryCode(countryCode: string) {
+  return countryCode === "D<<" ? "DEU" : countryCode
+}
+
 export function countryCodeAlpha2ToAlpha3(countryCodeAlpha2: string) {
   return ccAlpha2ToAlpha3[countryCodeAlpha2.toUpperCase() as keyof typeof ccAlpha2ToAlpha3]
 }

--- a/packages/zkpassport-utils/src/passport/getters.ts
+++ b/packages/zkpassport-utils/src/passport/getters.ts
@@ -1,5 +1,6 @@
 import { getOffsetInArray } from "@/utils"
 import { PassportViewModel } from ".."
+import { normalizeCountryCode } from "../country/country"
 
 export function getFirstNameRange(passport: PassportViewModel): [number, number] {
   const mrz = passport?.mrz
@@ -73,11 +74,7 @@ export function getNationalityRange(passport: PassportViewModel): [number, numbe
 
 export function getNationality(passport: PassportViewModel): string {
   const mrz = passport?.mrz
-  const countryCode = mrz.slice(...getNationalityRange(passport))
-  if (countryCode === "D<<") {
-    return "DEU"
-  }
-  return countryCode
+  return normalizeCountryCode(mrz.slice(...getNationalityRange(passport)))
 }
 
 export function getExpiryDateRange(passport: PassportViewModel): [number, number] {

--- a/packages/zkpassport-utils/tests/german-country-code.test.ts
+++ b/packages/zkpassport-utils/tests/german-country-code.test.ts
@@ -3,15 +3,13 @@ import { getNationality } from "../src/passport/getters"
 import { normalizeCountryCode } from "../src/country/country"
 import type { PassportViewModel } from "../src/types"
 
-// German documents carry "D<<" in the MRZ nationality and issuing country fields instead of the
-// ISO alpha-3 code "DEU". The circuits, the app and the query builder all use "DEU", so the
-// disclosed data parsed out of a proof has to normalize it too, or verification fails.
+// German MRZs carry "D<<" instead of "DEU", see normalizeCountryCode
 const GERMAN_PASSPORT_MRZ =
   "P<D<<MUSTERMANN<<ERIKA<<<<<<<<<<<<<<<<<<<<<<C01X00T478D<<6408125F2702283<<<<<<<<<<<<<<<4"
 const GERMAN_ID_CARD_MRZ =
   "IDD<<L01X00T471<<<<<<<<<<<<<<<6408125F2702283D<<<<<<<<<<<<<4MUSTERMANN<<ERIKA<<<<<<<<<<<<<"
 
-const disclose = (mrz: string, ...ranges: [number, number][]) => {
+const makeDisclosedBytes = (mrz: string, ...ranges: [number, number][]) => {
   const mask = new Array(90).fill(0)
   for (const [start, end] of ranges) mask.fill(1, start, end)
   return getDisclosedBytesFromMrzAndMask(mrz, mask)
@@ -32,12 +30,12 @@ describe("German country code normalization", () => {
     })
 
     it("discloses the nationality as DEU", () => {
-      const bytes = disclose(GERMAN_PASSPORT_MRZ, [54, 57])
+      const bytes = makeDisclosedBytes(GERMAN_PASSPORT_MRZ, [54, 57])
       expect(DisclosedData.fromDisclosedBytes(bytes, "passport").nationality).toBe("DEU")
     })
 
     it("discloses the issuing country as DEU", () => {
-      const bytes = disclose(GERMAN_PASSPORT_MRZ, [2, 5])
+      const bytes = makeDisclosedBytes(GERMAN_PASSPORT_MRZ, [2, 5])
       expect(DisclosedData.fromDisclosedBytes(bytes, "passport").issuingCountry).toBe("DEU")
     })
 
@@ -54,12 +52,12 @@ describe("German country code normalization", () => {
     })
 
     it("discloses the nationality as DEU", () => {
-      const bytes = disclose(GERMAN_ID_CARD_MRZ, [45, 48])
+      const bytes = makeDisclosedBytes(GERMAN_ID_CARD_MRZ, [45, 48])
       expect(DisclosedData.fromDisclosedBytes(bytes, "id_card").nationality).toBe("DEU")
     })
 
     it("discloses the issuing country as DEU", () => {
-      const bytes = disclose(GERMAN_ID_CARD_MRZ, [2, 5])
+      const bytes = makeDisclosedBytes(GERMAN_ID_CARD_MRZ, [2, 5])
       expect(DisclosedData.fromDisclosedBytes(bytes, "id_card").issuingCountry).toBe("DEU")
     })
 
@@ -71,7 +69,7 @@ describe("German country code normalization", () => {
   it("non-German documents keep their alpha-3 code", () => {
     const frenchMRZ =
       "P<FRAMARTIN<<MARIE<<<<<<<<<<<<<<<<<<<<<<<<<<12AB345670FRA6408125F2702283<<<<<<<<<<<<<<<4"
-    const bytes = disclose(frenchMRZ, [2, 5], [54, 57])
+    const bytes = makeDisclosedBytes(frenchMRZ, [2, 5], [54, 57])
     const data = DisclosedData.fromDisclosedBytes(bytes, "passport")
     expect(data.nationality).toBe("FRA")
     expect(data.issuingCountry).toBe("FRA")

--- a/packages/zkpassport-utils/tests/german-country-code.test.ts
+++ b/packages/zkpassport-utils/tests/german-country-code.test.ts
@@ -1,0 +1,79 @@
+import { DisclosedData, getDisclosedBytesFromMrzAndMask } from "../src/circuits/disclose"
+import { getNationality } from "../src/passport/getters"
+import { normalizeCountryCode } from "../src/country/country"
+import type { PassportViewModel } from "../src/types"
+
+// German documents carry "D<<" in the MRZ nationality and issuing country fields instead of the
+// ISO alpha-3 code "DEU". The circuits, the app and the query builder all use "DEU", so the
+// disclosed data parsed out of a proof has to normalize it too, or verification fails.
+const GERMAN_PASSPORT_MRZ =
+  "P<D<<MUSTERMANN<<ERIKA<<<<<<<<<<<<<<<<<<<<<<C01X00T478D<<6408125F2702283<<<<<<<<<<<<<<<4"
+const GERMAN_ID_CARD_MRZ =
+  "IDD<<L01X00T471<<<<<<<<<<<<<<<6408125F2702283D<<<<<<<<<<<<<4MUSTERMANN<<ERIKA<<<<<<<<<<<<<"
+
+const disclose = (mrz: string, ...ranges: [number, number][]) => {
+  const mask = new Array(90).fill(0)
+  for (const [start, end] of ranges) mask.fill(1, start, end)
+  return getDisclosedBytesFromMrzAndMask(mrz, mask)
+}
+
+describe("German country code normalization", () => {
+  it("normalizes D<< to DEU and leaves other codes untouched", () => {
+    expect(normalizeCountryCode("D<<")).toBe("DEU")
+    expect(normalizeCountryCode("FRA")).toBe("FRA")
+    expect(normalizeCountryCode("")).toBe("")
+  })
+
+  describe("passports (TD3)", () => {
+    it("the MRZ really holds D<< at the nationality and issuing country offsets", () => {
+      expect(GERMAN_PASSPORT_MRZ.length).toBe(88)
+      expect(GERMAN_PASSPORT_MRZ.slice(2, 5)).toBe("D<<")
+      expect(GERMAN_PASSPORT_MRZ.slice(54, 57)).toBe("D<<")
+    })
+
+    it("discloses the nationality as DEU", () => {
+      const bytes = disclose(GERMAN_PASSPORT_MRZ, [54, 57])
+      expect(DisclosedData.fromDisclosedBytes(bytes, "passport").nationality).toBe("DEU")
+    })
+
+    it("discloses the issuing country as DEU", () => {
+      const bytes = disclose(GERMAN_PASSPORT_MRZ, [2, 5])
+      expect(DisclosedData.fromDisclosedBytes(bytes, "passport").issuingCountry).toBe("DEU")
+    })
+
+    it("getNationality returns DEU", () => {
+      expect(getNationality({ mrz: GERMAN_PASSPORT_MRZ } as PassportViewModel)).toBe("DEU")
+    })
+  })
+
+  describe("id cards (TD1)", () => {
+    it("the MRZ really holds D<< at the nationality and issuing country offsets", () => {
+      expect(GERMAN_ID_CARD_MRZ.length).toBe(90)
+      expect(GERMAN_ID_CARD_MRZ.slice(2, 5)).toBe("D<<")
+      expect(GERMAN_ID_CARD_MRZ.slice(45, 48)).toBe("D<<")
+    })
+
+    it("discloses the nationality as DEU", () => {
+      const bytes = disclose(GERMAN_ID_CARD_MRZ, [45, 48])
+      expect(DisclosedData.fromDisclosedBytes(bytes, "id_card").nationality).toBe("DEU")
+    })
+
+    it("discloses the issuing country as DEU", () => {
+      const bytes = disclose(GERMAN_ID_CARD_MRZ, [2, 5])
+      expect(DisclosedData.fromDisclosedBytes(bytes, "id_card").issuingCountry).toBe("DEU")
+    })
+
+    it("getNationality returns DEU", () => {
+      expect(getNationality({ mrz: GERMAN_ID_CARD_MRZ } as PassportViewModel)).toBe("DEU")
+    })
+  })
+
+  it("non-German documents keep their alpha-3 code", () => {
+    const frenchMRZ =
+      "P<FRAMARTIN<<MARIE<<<<<<<<<<<<<<<<<<<<<<<<<<12AB345670FRA6408125F2702283<<<<<<<<<<<<<<<4"
+    const bytes = disclose(frenchMRZ, [2, 5], [54, 57])
+    const data = DisclosedData.fromDisclosedBytes(bytes, "passport")
+    expect(data.nationality).toBe("FRA")
+    expect(data.issuingCountry).toBe("FRA")
+  })
+})


### PR DESCRIPTION
German passports and ID cards failed verification whenever a query disclosed or matched nationality or issuing country. Germany is the only country whose machine-readable code (`D<<`) differs from its ISO code (`DEU`); the app reports `DEU` but the SDK compared it against the raw `D<<` read from the proof, so the check always failed. `D<<` is now normalized to `DEU` in one shared helper.

Includes patch bumps: `@zkpassport/utils` 0.37.5 (0.37.4 is already taken on npm by an interim publish), `@zkpassport/sdk` 0.16.2, `@zkpassport/ui` 0.16.2.

### Rollout order
1. Merge and publish `@zkpassport/utils`, then `@zkpassport/sdk`, then `@zkpassport/ui`
2. Redeploy the verifier API with the new packages, otherwise its fallback path keeps rejecting German documents