### PR TITLE
chore(workspace): Ignore .worktrees directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Ignored folders
+.worktrees
 .build
 .cache
 target


### PR DESCRIPTION
Adds `.worktrees` to `.gitignore` so git worktrees can live inside the repo root for parallel work without risking being committed.