### PR TITLE
ci: Accept attest-contracts scope in PR title check

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -24,7 +24,7 @@ jobs:
             build
           requireScope: false
           scopes: |
-            (contracts|registry|explorer|registry-sdk|sdk|ui|utils|workspace)(,(contracts|registry|explorer|registry-sdk|sdk|ui|utils|workspace))*
+            (attest-contracts|contracts|registry|explorer|registry-sdk|sdk|ui|utils|workspace)(,(attest-contracts|contracts|registry|explorer|registry-sdk|sdk|ui|utils|workspace))*
           subjectPattern: ^[A-Z].+$
           subjectPatternError: |
             The subject must start with an uppercase letter.
@@ -38,7 +38,7 @@ jobs:
         with:
           requireScope: true
           scopes: |
-            (contracts|registry|explorer|registry-sdk|sdk|ui|utils|workspace)(,(contracts|registry|explorer|registry-sdk|sdk|ui|utils|workspace))*
+            (attest-contracts|contracts|registry|explorer|registry-sdk|sdk|ui|utils|workspace)(,(attest-contracts|contracts|registry|explorer|registry-sdk|sdk|ui|utils|workspace))*
           subjectPattern: ^[A-Z].+$
           subjectPatternError: |
             The subject must start with an uppercase letter.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Use the discovered base in `git diff origin/<base>...HEAD` and `git log origin/<
 <commits_and_prs>
 Follow Conventional Commits: `fix(scope): Subject`, `feat(scope): Subject`, `chore(scope): Subject`, `refactor(scope): Subject`, `docs(scope): Subject`, `test(scope): Subject`. PRs are squashed to a single commit on merge, so during development just create normal commits — do not amend unless explicitly asked.
 
-Scope must match one of: (contracts|registry|explorer|registry-sdk|sdk|ui|utils|workspace)(,(contracts|registry|explorer|registry-sdk|sdk|ui|utils|workspace))*
+Scope must match one of: (attest-contracts|contracts|registry|explorer|registry-sdk|sdk|ui|utils|workspace)(,(attest-contracts|contracts|registry|explorer|registry-sdk|sdk|ui|utils|workspace))*
 
 Subject must start with an uppercase letter.
 


### PR DESCRIPTION
Adds the attest-contracts scope to the PR title check (both validation steps) and the CLAUDE.md scope list, ahead of the attest contracts PR.