### PR TITLE
feat(contracts,sdk): Enforce requested nullifier type during verification

### DIFF
--- a/packages/registry-contracts/src/VerifierHelper.sol
+++ b/packages/registry-contracts/src/VerifierHelper.sol
@@ -477,19 +477,22 @@ contract VerifierHelper {
     /**
      * @notice Enforces that the proof was generated with the expected nullifier type
      * @dev A mock type matches its real counterpart, as mock proofs are only accepted in dev mode
-     * @param nullifierType The expected nullifier type
+     * @param expectedNullifierType The expected nullifier type
      * @param publicInputs The public inputs of the proof
      */
-    function enforceNullifierType(NullifierType nullifierType, bytes32[] calldata publicInputs) external pure {
-        require(_realNullifierType(getNullifierType(publicInputs)) == nullifierType, "Invalid nullifier type");
+    function enforceNullifierType(NullifierType expectedNullifierType, bytes32[] calldata publicInputs) external pure {
+        require(_realNullifierType(publicInputs) == expectedNullifierType, "Invalid nullifier type");
     }
 
-    function _realNullifierType(NullifierType nullifierType) private pure returns (NullifierType) {
-        if (nullifierType == NullifierType.NON_SALTED_MOCK_NULLIFIER) {
-            return NullifierType.NON_SALTED_NULLIFIER;
-        }
+    function _realNullifierType(bytes32[] calldata publicInputs) private pure returns (NullifierType) {
+        NullifierType nullifierType = getNullifierType(publicInputs);
         if (nullifierType == NullifierType.SALTED_MOCK_NULLIFIER) {
             return NullifierType.SALTED_NULLIFIER;
+        }
+        if (nullifierType == NullifierType.NON_SALTED_MOCK_NULLIFIER) {
+            // Mock IDs keep their mock type even when the nullifier is hidden
+            bool hasNullifier = publicInputs[publicInputs.length - 2] != bytes32(0);
+            return hasNullifier ? NullifierType.NON_SALTED_NULLIFIER : NullifierType.NONE_NULLIFIER;
         }
         return nullifierType;
     }

--- a/packages/registry-contracts/src/VerifierHelper.sol
+++ b/packages/registry-contracts/src/VerifierHelper.sol
@@ -14,7 +14,7 @@ import {DateUtils} from "./lib/DateUtils.sol";
 import {StringUtils} from "./lib/StringUtils.sol";
 import {InputsExtractor} from "./lib/InputsExtractor.sol";
 import {SECONDS_BETWEEN_1900_AND_1970, PublicInput, AppAttest, RegistryID} from "./lib/Constants.sol";
-import {ProofType, DisclosedData, BoundData, FaceMatchMode, Environment, OS} from "./lib/Types.sol";
+import {ProofType, DisclosedData, BoundData, FaceMatchMode, Environment, OS, NullifierType} from "./lib/Types.sol";
 
 contract VerifierHelper {
     RootRegistry public immutable rootRegistry;
@@ -463,6 +463,35 @@ contract VerifierHelper {
      */
     function getProofTimestamp(bytes32[] calldata publicInputs) external pure returns (uint256) {
         return uint256(publicInputs[PublicInput.CURRENT_DATE_INDEX]);
+    }
+
+    /**
+     * @notice Gets the nullifier type the proof was generated with
+     * @param publicInputs The public inputs of the proof
+     * @return The nullifier type of the proof
+     */
+    function getNullifierType(bytes32[] calldata publicInputs) public pure returns (NullifierType) {
+        return NullifierType(uint256(publicInputs[publicInputs.length - 3]));
+    }
+
+    /**
+     * @notice Enforces that the proof was generated with the expected nullifier type
+     * @dev A mock type matches its real counterpart, as mock proofs are only accepted in dev mode
+     * @param nullifierType The expected nullifier type
+     * @param publicInputs The public inputs of the proof
+     */
+    function enforceNullifierType(NullifierType nullifierType, bytes32[] calldata publicInputs) external pure {
+        require(_realNullifierType(getNullifierType(publicInputs)) == nullifierType, "Invalid nullifier type");
+    }
+
+    function _realNullifierType(NullifierType nullifierType) private pure returns (NullifierType) {
+        if (nullifierType == NullifierType.NON_SALTED_MOCK_NULLIFIER) {
+            return NullifierType.NON_SALTED_NULLIFIER;
+        }
+        if (nullifierType == NullifierType.SALTED_MOCK_NULLIFIER) {
+            return NullifierType.SALTED_NULLIFIER;
+        }
+        return nullifierType;
     }
 
     /**

--- a/packages/registry-contracts/test/VerifierHelper.t.sol
+++ b/packages/registry-contracts/test/VerifierHelper.t.sol
@@ -1,0 +1,52 @@
+pragma solidity ^0.8.30;
+
+import "forge-std/Test.sol";
+import "../src/RootRegistry.sol";
+import "../src/VerifierHelper.sol";
+import {NullifierType} from "../src/lib/Types.sol";
+
+contract VerifierHelperTest is Test {
+    VerifierHelper public helper;
+
+    function setUp() public {
+        helper = new VerifierHelper(new RootRegistry(address(0x1), address(0x2)));
+    }
+
+    function publicInputsWithNullifierType(NullifierType nullifierType) internal pure returns (bytes32[] memory) {
+        bytes32[] memory publicInputs = new bytes32[](8);
+        publicInputs[publicInputs.length - 3] = bytes32(uint256(nullifierType));
+        return publicInputs;
+    }
+
+    function testGetNullifierType() public view {
+        bytes32[] memory publicInputs = publicInputsWithNullifierType(NullifierType.SALTED_NULLIFIER);
+
+        assertEq(uint256(helper.getNullifierType(publicInputs)), uint256(NullifierType.SALTED_NULLIFIER));
+    }
+
+    function testEnforceNullifierTypeAcceptsMatchingType() public view {
+        bytes32[] memory publicInputs = publicInputsWithNullifierType(NullifierType.SALTED_NULLIFIER);
+
+        helper.enforceNullifierType(NullifierType.SALTED_NULLIFIER, publicInputs);
+    }
+
+    function testEnforceNullifierTypeRejectsMismatchedType() public {
+        bytes32[] memory publicInputs = publicInputsWithNullifierType(NullifierType.NON_SALTED_NULLIFIER);
+
+        vm.expectRevert("Invalid nullifier type");
+        helper.enforceNullifierType(NullifierType.SALTED_NULLIFIER, publicInputs);
+    }
+
+    function testEnforceNullifierTypeAcceptsMockOfExpectedType() public view {
+        bytes32[] memory publicInputs = publicInputsWithNullifierType(NullifierType.SALTED_MOCK_NULLIFIER);
+
+        helper.enforceNullifierType(NullifierType.SALTED_NULLIFIER, publicInputs);
+    }
+
+    function testEnforceNullifierTypeRejectsMockOfAnotherType() public {
+        bytes32[] memory publicInputs = publicInputsWithNullifierType(NullifierType.NON_SALTED_MOCK_NULLIFIER);
+
+        vm.expectRevert("Invalid nullifier type");
+        helper.enforceNullifierType(NullifierType.SALTED_NULLIFIER, publicInputs);
+    }
+}

--- a/packages/registry-contracts/test/VerifierHelper.t.sol
+++ b/packages/registry-contracts/test/VerifierHelper.t.sol
@@ -13,8 +13,17 @@ contract VerifierHelperTest is Test {
     }
 
     function publicInputsWithNullifierType(NullifierType nullifierType) internal pure returns (bytes32[] memory) {
+        return publicInputsWithNullifierType(nullifierType, bytes32(uint256(1)));
+    }
+
+    function publicInputsWithNullifierType(NullifierType nullifierType, bytes32 nullifier)
+        internal
+        pure
+        returns (bytes32[] memory)
+    {
         bytes32[] memory publicInputs = new bytes32[](8);
         publicInputs[publicInputs.length - 3] = bytes32(uint256(nullifierType));
+        publicInputs[publicInputs.length - 2] = nullifier;
         return publicInputs;
     }
 
@@ -48,5 +57,19 @@ contract VerifierHelperTest is Test {
 
         vm.expectRevert("Invalid nullifier type");
         helper.enforceNullifierType(NullifierType.SALTED_NULLIFIER, publicInputs);
+    }
+
+    function testEnforceNullifierTypeAcceptsMockWithHiddenNullifierForNone() public view {
+        bytes32[] memory publicInputs =
+            publicInputsWithNullifierType(NullifierType.NON_SALTED_MOCK_NULLIFIER, bytes32(0));
+
+        helper.enforceNullifierType(NullifierType.NONE_NULLIFIER, publicInputs);
+    }
+
+    function testEnforceNullifierTypeRejectsMockWithNullifierForNone() public {
+        bytes32[] memory publicInputs = publicInputsWithNullifierType(NullifierType.NON_SALTED_MOCK_NULLIFIER);
+
+        vm.expectRevert("Invalid nullifier type");
+        helper.enforceNullifierType(NullifierType.NONE_NULLIFIER, publicInputs);
     }
 }

--- a/packages/zkpassport-sdk/src/index.ts
+++ b/packages/zkpassport-sdk/src/index.ts
@@ -36,6 +36,7 @@ import {
   QueryResultErrors,
   VerifierMode,
   VerificationResult,
+  RequestedNullifierType,
 } from "./types"
 import { PublicInputChecker } from "./public-input-checker"
 import { SolidityVerifier } from "./solidity-verifier"
@@ -108,6 +109,31 @@ function generalCompare(
   }
 }
 
+function realNullifierType(nullifierType: NullifierType): NullifierType {
+  if (nullifierType === NullifierType.NON_SALTED_MOCK) return NullifierType.NON_SALTED
+  if (nullifierType === NullifierType.SALTED_MOCK) return NullifierType.SALTED
+  return nullifierType
+}
+
+function enforceUniqueIdentifierType(
+  result: VerificationResult,
+  requestedType: RequestedNullifierType | undefined,
+): VerificationResult {
+  if (requestedType === undefined || !result.verified) return result
+  const actualType = result.uniqueIdentifierType
+  if (actualType !== undefined && realNullifierType(actualType) === requestedType) return result
+  const actualName = actualType === undefined ? "none" : NullifierType[actualType]
+  console.warn(
+    `Unique identifier type mismatch: requested ${NullifierType[requestedType]}, got ${actualName}`,
+  )
+  return {
+    ...result,
+    uniqueIdentifier: undefined,
+    uniqueIdentifierType: undefined,
+    verified: false,
+  }
+}
+
 export {
   SANCTIONED_COUNTRIES,
   EU_COUNTRIES,
@@ -148,7 +174,7 @@ export class ZKPassport {
       validity: number
       mode: ProofMode
       devMode: boolean
-      uniqueIdentifierType: NullifierType | undefined
+      uniqueIdentifierType: RequestedNullifierType | undefined
       oprfKeyId: string | null
       returnDeepLink: string | undefined
     }
@@ -233,6 +259,7 @@ export class ZKPassport {
         scope: this.topicToService[topic]?.scope,
         devMode: this.topicToLocalConfig[topic]?.devMode,
         oprfKeyId: this.topicToLocalConfig[topic]?.oprfKeyId ?? undefined,
+        uniqueIdentifierType: this.topicToLocalConfig[topic]?.uniqueIdentifierType,
       })
     logger.debug("Verification complete, verified:", verified)
     const hasFailedProofs = this.topicToFailedProofCount[topic] > 0
@@ -675,7 +702,7 @@ export class ZKPassport {
     projectID?: string
     validity?: number
     devMode?: boolean
-    uniqueIdentifierType?: NullifierType.NON_SALTED | NullifierType.SALTED | NullifierType.NONE
+    uniqueIdentifierType?: RequestedNullifierType
     oprfKeyId?: string
     topicOverride?: string
     keyPairOverride?: { privateKey: Uint8Array; publicKey: Uint8Array }
@@ -782,6 +809,8 @@ export class ZKPassport {
    * @param writingDirectory The directory (e.g. `./tmp`) where the necessary temporary artifacts for verification are written to.
    * It should only be needed when running the `verify` function on a server with restricted write access (e.g. Vercel)
    * @param oprfKeyId The OPRF key id used in the original request, if any.
+   * @param uniqueIdentifierType The unique identifier type requested in the original request, if any.
+   * Proofs using a different type fail verification.
    * @param verifierMode "local" verifies with the verifier bundled in this SDK, "api" with the
    * ZKPassport verifier API, and "auto" (default) verifies locally but defers to the API when
    * the local result is not verified — e.g. proofs from a newer bb version than this SDK supports.
@@ -797,6 +826,7 @@ export class ZKPassport {
     devMode = false,
     writingDirectory,
     oprfKeyId,
+    uniqueIdentifierType,
     verifierMode = "auto",
   }: {
     proofs: Array<ProofResult>
@@ -807,6 +837,7 @@ export class ZKPassport {
     devMode?: boolean
     writingDirectory?: string
     oprfKeyId?: string
+    uniqueIdentifierType?: RequestedNullifierType
     verifierMode?: VerifierMode
   }): Promise<VerificationResult> {
     if (!originalQuery || !queryResult) {
@@ -825,22 +856,25 @@ export class ZKPassport {
     const params = { proofs, originalQuery, queryResult, validity, scope, devMode, oprfKeyId }
     const localParams = { ...params, writingDirectory }
     const apiParams = { ...params, domain: this.domain }
+    const requestedType = oprfKeyId ? NullifierType.SALTED : uniqueIdentifierType
 
+    let result: VerificationResult
     if (verifierMode === "local") {
-      return this.verifyLocally(localParams)
+      result = await this.verifyLocally(localParams)
+    } else if (verifierMode === "api") {
+      result = (await verifyWithVerifierApi(apiParams)) ?? notVerified
+    } else {
+      let localResult: VerificationResult | undefined
+      try {
+        localResult = await this.verifyLocally(localParams)
+      } catch (e) {
+        console.warn("Local proof verification failed:", e)
+      }
+      result = localResult?.verified
+        ? localResult
+        : ((await verifyWithVerifierApi(apiParams)) ?? localResult ?? notVerified)
     }
-    if (verifierMode === "api") {
-      return (await verifyWithVerifierApi(apiParams)) ?? notVerified
-    }
-
-    let localResult: VerificationResult | undefined
-    try {
-      localResult = await this.verifyLocally(localParams)
-      if (localResult.verified) return localResult
-    } catch (e) {
-      console.warn("Local proof verification failed:", e)
-    }
-    return (await verifyWithVerifierApi(apiParams)) ?? localResult ?? notVerified
+    return enforceUniqueIdentifierType(result, requestedType)
   }
 
   private async verifyLocally({
@@ -1043,7 +1077,7 @@ export class ZKPassport {
     const oprfKeyId = this.topicToLocalConfig[requestId].oprfKeyId
     const returnDeepLink = this.topicToLocalConfig[requestId].returnDeepLink
     let url = `https://zkpassport.id/r?d=${this.domain}&t=${requestId}&c=${encodeURIComponent(base64Config)}&s=${encodeURIComponent(base64Service)}&p=${pubkey}&m=${this.topicToLocalConfig[requestId].mode}&v=${VERSION}&dt=${timestamp}&dev=${this.topicToLocalConfig[requestId].devMode ? "1" : "0"}`
-    if (nullifierType) {
+    if (nullifierType !== undefined) {
       url += `&nt=${nullifierType}`
     }
     if (oprfKeyId) {

--- a/packages/zkpassport-sdk/src/index.ts
+++ b/packages/zkpassport-sdk/src/index.ts
@@ -119,7 +119,7 @@ function enforceUniqueIdentifierType(
   result: VerificationResult,
   requestedType: RequestedNullifierType | undefined,
 ): VerificationResult {
-  if (requestedType === undefined || !result.verified) return result
+  if (requestedType == null || !result.verified) return result
   const actualType = result.uniqueIdentifierType
   if (actualType !== undefined && realNullifierType(actualType) === requestedType) return result
   const actualName = actualType === undefined ? "none" : NullifierType[actualType]
@@ -1077,7 +1077,7 @@ export class ZKPassport {
     const oprfKeyId = this.topicToLocalConfig[requestId].oprfKeyId
     const returnDeepLink = this.topicToLocalConfig[requestId].returnDeepLink
     let url = `https://zkpassport.id/r?d=${this.domain}&t=${requestId}&c=${encodeURIComponent(base64Config)}&s=${encodeURIComponent(base64Service)}&p=${pubkey}&m=${this.topicToLocalConfig[requestId].mode}&v=${VERSION}&dt=${timestamp}&dev=${this.topicToLocalConfig[requestId].devMode ? "1" : "0"}`
-    if (nullifierType !== undefined) {
+    if (nullifierType != null) {
       url += `&nt=${nullifierType}`
     }
     if (oprfKeyId) {

--- a/packages/zkpassport-sdk/src/index.ts
+++ b/packages/zkpassport-sdk/src/index.ts
@@ -109,10 +109,16 @@ function generalCompare(
   }
 }
 
-function realNullifierType(nullifierType: NullifierType): NullifierType {
-  if (nullifierType === NullifierType.NON_SALTED_MOCK) return NullifierType.NON_SALTED
-  if (nullifierType === NullifierType.SALTED_MOCK) return NullifierType.SALTED
-  return nullifierType
+function realNullifierType({
+  uniqueIdentifier,
+  uniqueIdentifierType,
+}: VerificationResult): NullifierType | undefined {
+  if (uniqueIdentifierType === NullifierType.SALTED_MOCK) return NullifierType.SALTED
+  if (uniqueIdentifierType === NullifierType.NON_SALTED_MOCK) {
+    // Mock IDs keep their mock type even when the identifier is hidden
+    return uniqueIdentifier === undefined ? NullifierType.NONE : NullifierType.NON_SALTED
+  }
+  return uniqueIdentifierType
 }
 
 function enforceUniqueIdentifierType(
@@ -120,11 +126,11 @@ function enforceUniqueIdentifierType(
   requestedType: RequestedNullifierType | undefined,
 ): VerificationResult {
   if (requestedType == null || !result.verified) return result
-  const actualType = result.uniqueIdentifierType
-  if (actualType !== undefined && realNullifierType(actualType) === requestedType) return result
-  const actualName = actualType === undefined ? "none" : NullifierType[actualType]
+  if (realNullifierType(result) === requestedType) return result
+  const proofType = result.uniqueIdentifierType
+  const proofTypeName = proofType === undefined ? "missing" : NullifierType[proofType]
   console.warn(
-    `Unique identifier type mismatch: requested ${NullifierType[requestedType]}, got ${actualName}`,
+    `Unique identifier type mismatch: requested ${NullifierType[requestedType]}, got ${proofTypeName}`,
   )
   return {
     ...result,

--- a/packages/zkpassport-sdk/src/types.ts
+++ b/packages/zkpassport-sdk/src/types.ts
@@ -53,6 +53,12 @@ export type QueryResultErrors = {
 // but defers to the API when the local result is not verified.
 export type VerifierMode = "auto" | "local" | "api"
 
+// The nullifier types a service can ask for. The mock ones only ever come from the app in dev mode.
+export type RequestedNullifierType =
+  | NullifierType.NON_SALTED
+  | NullifierType.SALTED
+  | NullifierType.NONE
+
 export type VerificationResult = {
   uniqueIdentifier: string | undefined
   uniqueIdentifierType: NullifierType | undefined

--- a/packages/zkpassport-sdk/tests/proof-submission.test.ts
+++ b/packages/zkpassport-sdk/tests/proof-submission.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { ZKPassport } from "../src/index"
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test"
+import { NullifierType, ZKPassport } from "../src/index"
 import { MockWebSocket } from "./helpers/mock-websocket"
 
 describe("Proof submission", () => {
@@ -143,6 +144,28 @@ describe("Proof submission", () => {
 
     await (zk as any).handleResult(topic)
 
+    expect(fetchedUrls).toEqual([])
+  })
+
+  test("onResult reports failure when the proof does not use the requested unique identifier type", async () => {
+    const zk = new ZKPassport("localhost")
+    const { topic } = primeForHandleResult(zk, { verifyResult: { verified: true } })
+    // Use the real verify() so the type check runs; only stub the proof verification under it.
+    delete (zk as any).verify
+    const localSpy = spyOn(ZKPassport.prototype as any, "verifyLocally").mockResolvedValue({
+      verified: true,
+      uniqueIdentifier: "uid-1",
+      uniqueIdentifierType: NullifierType.NON_SALTED,
+    })
+    ;(zk as any).topicToLocalConfig[topic].uniqueIdentifierType = NullifierType.SALTED
+    const results: any[] = []
+    ;(zk as any).onResultCallbacks[topic].push((response: any) => results.push(response))
+
+    await (zk as any).handleResult(topic)
+
+    localSpy.mockRestore()
+    expect(results).toHaveLength(1)
+    expect(results[0]).toMatchObject({ verified: false, uniqueIdentifier: undefined })
     expect(fetchedUrls).toEqual([])
   })
 

--- a/packages/zkpassport-sdk/tests/query-builder.test.ts
+++ b/packages/zkpassport-sdk/tests/query-builder.test.ts
@@ -845,6 +845,17 @@ describe("Salted nullifier facematch validation", () => {
     })
     expect(() => qb.done()).not.toThrow()
   })
+
+  test("encodes nt=0 in the request URL", async () => {
+    const qb = await zkPassport.request({
+      name: "Test App",
+      logo: "https://test.com/logo.png",
+      purpose: "Testing salted validation",
+      uniqueIdentifierType: NullifierType.NON_SALTED,
+    })
+    const result = qb.disclose("firstname").done()
+    expect(result.url).toContain(`&nt=${NullifierType.NON_SALTED}`)
+  })
 })
 
 describe("NONE nullifier type requests", () => {

--- a/packages/zkpassport-sdk/tests/query-builder.test.ts
+++ b/packages/zkpassport-sdk/tests/query-builder.test.ts
@@ -856,6 +856,17 @@ describe("Salted nullifier facematch validation", () => {
     const result = qb.disclose("firstname").done()
     expect(result.url).toContain(`&nt=${NullifierType.NON_SALTED}`)
   })
+
+  test("omits nt from the URL when uniqueIdentifierType is null", async () => {
+    const qb = await zkPassport.request({
+      name: "Test App",
+      logo: "https://test.com/logo.png",
+      purpose: "Testing salted validation",
+      uniqueIdentifierType: null as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+    })
+    const result = qb.disclose("firstname").done()
+    expect(result.url).not.toContain("&nt=")
+  })
 })
 
 describe("NONE nullifier type requests", () => {

--- a/packages/zkpassport-sdk/tests/verifier-api.test.ts
+++ b/packages/zkpassport-sdk/tests/verifier-api.test.ts
@@ -171,6 +171,25 @@ describe("verify() modes and the verifier API", () => {
     expect(result).toEqual(localResult as any)
   })
 
+  test("ignores a null unique identifier type from untyped callers", async () => {
+    const localResult = {
+      verified: true,
+      uniqueIdentifier: "local-uid",
+      uniqueIdentifierType: NullifierType.NON_SALTED,
+    }
+    localSpy.mockResolvedValue(localResult)
+    const zk = new ZKPassport("example.com")
+
+    const result = await zk.verify({
+      proofs,
+      originalQuery,
+      queryResult,
+      uniqueIdentifierType: null as any,
+    })
+
+    expect(result).toEqual(localResult as any)
+  })
+
   test("an oprf key requires a salted unique identifier", async () => {
     localSpy.mockResolvedValue({
       verified: true,

--- a/packages/zkpassport-sdk/tests/verifier-api.test.ts
+++ b/packages/zkpassport-sdk/tests/verifier-api.test.ts
@@ -176,6 +176,48 @@ describe("verify() modes and the verifier API", () => {
     expect(result).toEqual(localResult as any)
   })
 
+  test("accepts a mock proof with no unique identifier for a NONE request", async () => {
+    const localResult = {
+      verified: true,
+      uniqueIdentifier: undefined,
+      uniqueIdentifierType: NullifierType.NON_SALTED_MOCK,
+    }
+    localSpy.mockResolvedValue(localResult)
+    const zk = new ZKPassport("example.com")
+
+    const result = await zk.verify({
+      proofs,
+      originalQuery,
+      queryResult,
+      devMode: true,
+      uniqueIdentifierType: NullifierType.NONE,
+    })
+
+    expect(result).toEqual(localResult as any)
+  })
+
+  test("rejects a mock proof carrying a unique identifier for a NONE request", async () => {
+    localSpy.mockResolvedValue({
+      verified: true,
+      uniqueIdentifier: "local-uid",
+      uniqueIdentifierType: NullifierType.NON_SALTED_MOCK,
+    })
+    const zk = new ZKPassport("example.com")
+
+    const result = await zk.verify({
+      proofs,
+      originalQuery,
+      queryResult,
+      devMode: true,
+      uniqueIdentifierType: NullifierType.NONE,
+    })
+
+    expect(result).toEqual(notVerified)
+    expect(warnings).toEqual([
+      "Unique identifier type mismatch: requested NONE, got NON_SALTED_MOCK",
+    ])
+  })
+
   test("ignores a null unique identifier type from untyped callers", async () => {
     const localResult = {
       verified: true,

--- a/packages/zkpassport-sdk/tests/verifier-api.test.ts
+++ b/packages/zkpassport-sdk/tests/verifier-api.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test"
-import { ZKPassport } from "../src/index"
+import { NullifierType, ZKPassport } from "../src/index"
 
 describe("verify() modes and the verifier API", () => {
   let originalFetch: typeof globalThis.fetch
@@ -131,6 +131,78 @@ describe("verify() modes and the verifier API", () => {
 
     expect(result).toEqual(notVerified)
     expect(localSpy).not.toHaveBeenCalled()
+  })
+
+  test("rejects proofs whose unique identifier type is not the requested one", async () => {
+    localSpy.mockResolvedValue({
+      verified: true,
+      uniqueIdentifier: "local-uid",
+      uniqueIdentifierType: NullifierType.NON_SALTED,
+    })
+    const zk = new ZKPassport("example.com")
+
+    const result = await zk.verify({
+      proofs,
+      originalQuery,
+      queryResult,
+      uniqueIdentifierType: NullifierType.SALTED,
+    })
+
+    expect(result).toEqual(notVerified)
+  })
+
+  test("accepts a mock unique identifier type for the requested real one", async () => {
+    const localResult = {
+      verified: true,
+      uniqueIdentifier: "local-uid",
+      uniqueIdentifierType: NullifierType.SALTED_MOCK,
+    }
+    localSpy.mockResolvedValue(localResult)
+    const zk = new ZKPassport("example.com")
+
+    const result = await zk.verify({
+      proofs,
+      originalQuery,
+      queryResult,
+      devMode: true,
+      uniqueIdentifierType: NullifierType.SALTED,
+    })
+
+    expect(result).toEqual(localResult as any)
+  })
+
+  test("an oprf key requires a salted unique identifier", async () => {
+    localSpy.mockResolvedValue({
+      verified: true,
+      uniqueIdentifier: "local-uid",
+      uniqueIdentifierType: NullifierType.NON_SALTED,
+    })
+    const zk = new ZKPassport("example.com")
+
+    const result = await zk.verify({ proofs, originalQuery, queryResult, oprfKeyId: "key-1" })
+
+    expect(result).toEqual(notVerified)
+  })
+
+  test("enforces the requested unique identifier type on the API verdict", async () => {
+    globalThis.fetch = (async () => {
+      return Response.json({
+        verified: true,
+        uniqueIdentifier: "uid-1",
+        uniqueIdentifierType: NullifierType.NON_SALTED,
+      })
+    }) as unknown as typeof globalThis.fetch
+    const zk = new ZKPassport("example.com")
+
+    const result = await zk.verify({
+      proofs,
+      originalQuery,
+      queryResult,
+      verifierMode: "api",
+      uniqueIdentifierType: NullifierType.NONE,
+    })
+
+    expect(result).toEqual(notVerified)
   })
 
   test("api returns the API's queryResultErrors when it rejects the proofs", async () => {

--- a/packages/zkpassport-sdk/tests/verifier-api.test.ts
+++ b/packages/zkpassport-sdk/tests/verifier-api.test.ts
@@ -5,6 +5,7 @@ import { NullifierType, ZKPassport } from "../src/index"
 describe("verify() modes and the verifier API", () => {
   let originalFetch: typeof globalThis.fetch
   let originalWarn: typeof console.warn
+  let warnings: string[]
   let fetchedUrls: string[]
   let fetchedBodies: string[]
   let localSpy: ReturnType<typeof spyOn>
@@ -27,7 +28,10 @@ describe("verify() modes and the verifier API", () => {
   beforeEach(() => {
     originalFetch = globalThis.fetch
     originalWarn = console.warn
-    console.warn = () => {}
+    warnings = []
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "))
+    }
     fetchedUrls = []
     fetchedBodies = []
     globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -149,6 +153,7 @@ describe("verify() modes and the verifier API", () => {
     })
 
     expect(result).toEqual(notVerified)
+    expect(warnings).toEqual(["Unique identifier type mismatch: requested SALTED, got NON_SALTED"])
   })
 
   test("accepts a mock unique identifier type for the requested real one", async () => {
@@ -201,6 +206,7 @@ describe("verify() modes and the verifier API", () => {
     const result = await zk.verify({ proofs, originalQuery, queryResult, oprfKeyId: "key-1" })
 
     expect(result).toEqual(notVerified)
+    expect(warnings).toEqual(["Unique identifier type mismatch: requested SALTED, got NON_SALTED"])
   })
 
   test("enforces the requested unique identifier type on the API verdict", async () => {
@@ -222,6 +228,7 @@ describe("verify() modes and the verifier API", () => {
     })
 
     expect(result).toEqual(notVerified)
+    expect(warnings).toEqual(["Unique identifier type mismatch: requested NONE, got NON_SALTED"])
   })
 
   test("api returns the API's queryResultErrors when it rejects the proofs", async () => {


### PR DESCRIPTION
Nothing verified that proofs use the nullifier type the service requested — a tampered prover could return a different type and still pass. An `oprfKeyId` request could even pass with a non-salted proof, skipping the OPRF key check.

### Key changes
- `verify()` rejects proofs that don't use the requested `uniqueIdentifierType`
- New `VerifierHelper.enforceNullifierType` for on-chain integrators

### Related PRs
- zkpassport/zkpassport-proof-verifier#3 — the `/verify` endpoint used by the `api`/`auto` verifier modes. Enforcement runs client-side on its result, so no API change is needed; it could later accept `uniqueIdentifierType` for server-side enforcement too.
- zkpassport/zkpassport-mobile-app#318 — app support for `NONE` (proofs carrying no unique identifier)
- zkpassport/circuits#152 — `NONE` nullifier type in circuits (merged, not yet in a published circuit version)

### Rollout order
1. Deploy the new `VerifierHelper` and register it via `updateHelper` before integrators use `enforceNullifierType`.
2. `NONE` requests fail verification under enforcement until the app honors them: zkpassport-mobile-app#318 must be merged and deployed, with a published circuit version including circuits#152, before `NONE` is advertised. (Previously such requests passed while still returning an identifier — failing is the fix, but it is a behavior change.)
3. `SALTED`/`NON_SALTED` enforcement needs no prerequisites — the app and the deployed verifier API already support both.

FIX: https://linear.app/aztec-labs/issue/ZKP-427/sdk-enforce-nullifiertype