### PR TITLE
ci: Allow the aztec scope in PR titles

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -24,7 +24,7 @@ jobs:
             build
           requireScope: false
           scopes: |
-            (contracts|registry|explorer|registry-sdk|sdk|ui|utils|workspace)(,(contracts|registry|explorer|registry-sdk|sdk|ui|utils|workspace))*
+            (aztec|contracts|registry|explorer|registry-sdk|sdk|ui|utils|workspace)(,(aztec|contracts|registry|explorer|registry-sdk|sdk|ui|utils|workspace))*
           subjectPattern: ^[A-Z].+$
           subjectPatternError: |
             The subject must start with an uppercase letter.
@@ -38,7 +38,7 @@ jobs:
         with:
           requireScope: true
           scopes: |
-            (contracts|registry|explorer|registry-sdk|sdk|ui|utils|workspace)(,(contracts|registry|explorer|registry-sdk|sdk|ui|utils|workspace))*
+            (aztec|contracts|registry|explorer|registry-sdk|sdk|ui|utils|workspace)(,(aztec|contracts|registry|explorer|registry-sdk|sdk|ui|utils|workspace))*
           subjectPattern: ^[A-Z].+$
           subjectPatternError: |
             The subject must start with an uppercase letter.


### PR DESCRIPTION
The PR-title scope allowlist mirrors `packages/*` and predates `packages/aztec`. Adds `aztec` so the zkp Aztec stack PRs (#269–#274) can use it. Same shape as #161, which added the `contracts` scope.

Note: `check-pr.yml` runs on `pull_request_target`, so this only takes effect once merged to `main` — it can't be fixed from the feature branches themselves.
