### PR TITLE
chore(utils): Publish conformance vectors for the parameter-commitment scheme

### DIFF
--- a/packages/zkpassport-utils/conformance/vectors.json
+++ b/packages/zkpassport-utils/conformance/vectors.json
@@ -1,0 +1,30 @@
+{
+  "description": "Conformance vectors for the ZKPassport parameter-commitment scheme (Poseidon2 variant). Every implementation of the scheme must reproduce each commitment from its params: this package's TS functions (tests/conformance.test.ts), the circuits repo's Noir libs, and downstream verifiers such as zkpassport.nr's commitment wrappers.",
+  "vectors": [
+    {
+      "name": "age_18_plus",
+      "proofType": "age",
+      "params": { "minAge": 18, "maxAge": 0 },
+      "commitment": "0x2ccd6b1a6a0758a11ad3531939e69db3e11adbe90131cb38b69df90d55887d83"
+    },
+    {
+      "name": "disclose_nationality_aus",
+      "proofType": "disclose",
+      "params": {
+        "mrzLength": 90,
+        "maskIndices": [54, 55, 56],
+        "disclosedText": "AUS"
+      },
+      "commitment": "0x1b6d3f9e55b8456c4baf5f21d14e5e425b6d23df44e3067f561b0ab41cf7b59f"
+    },
+    {
+      "name": "bind_user_address",
+      "proofType": "bind",
+      "params": {
+        "userAddress": "0x1122334455667788990011223344556677889900112233445566778899001122",
+        "maxLength": 509
+      },
+      "commitment": "0x1fe004f678d9cf91bf41adf1ee3cd1b12f30799a167cc8c4c9307fa9a7399970"
+    }
+  ]
+}

--- a/packages/zkpassport-utils/package.json
+++ b/packages/zkpassport-utils/package.json
@@ -96,7 +96,8 @@
   },
   "files": [
     "dist/esm",
-    "dist/cjs"
+    "dist/cjs",
+    "conformance"
   ],
   "keywords": [
     "zkpassport",

--- a/packages/zkpassport-utils/tests/conformance.test.ts
+++ b/packages/zkpassport-utils/tests/conformance.test.ts
@@ -1,0 +1,43 @@
+// Holds this package to conformance/vectors.json, the published reference vectors for the
+// parameter-commitment scheme. Other implementations (the circuits repo's Noir libs and
+// downstream verifiers) are expected to test against the same file, so a vector only changes
+// when the scheme itself changes.
+import vectors from "../conformance/vectors.json"
+import { getAgeParameterCommitment } from "../src/circuits/age"
+import { formatBoundData, getBindParameterCommitment } from "../src/circuits/bind"
+import { getDiscloseParameterCommitment } from "../src/circuits/disclose"
+
+type Vector = { name: string; proofType: string; params: Record<string, any>; commitment: string }
+const byType = Object.fromEntries((vectors.vectors as Vector[]).map((v) => [v.proofType, v]))
+const hex = (b: bigint) => "0x" + b.toString(16).padStart(64, "0")
+
+describe("Conformance vectors", () => {
+  test("every vector is checked here", () => {
+    expect(vectors.vectors.map((v) => v.proofType).sort()).toEqual(["age", "bind", "disclose"])
+  })
+
+  test("age", async () => {
+    const { params, commitment } = byType.age
+    const result = await getAgeParameterCommitment(params.minAge, params.maxAge)
+    expect(hex(result)).toEqual(commitment)
+  })
+
+  test("disclose", async () => {
+    const { params, commitment } = byType.disclose
+    const mask = Array.from({ length: params.mrzLength }, () => 0)
+    const disclosed = Array.from({ length: params.mrzLength }, () => 0)
+    params.maskIndices.forEach((mrzIndex: number, i: number) => {
+      mask[mrzIndex] = 1
+      disclosed[mrzIndex] = params.disclosedText.charCodeAt(i)
+    })
+    const result = await getDiscloseParameterCommitment(mask, disclosed)
+    expect(hex(result)).toEqual(commitment)
+  })
+
+  test("bind", async () => {
+    const { params, commitment } = byType.bind
+    const data = formatBoundData({ user_address: params.userAddress })
+    const result = await getBindParameterCommitment(data, params.maxLength)
+    expect(hex(result)).toEqual(commitment)
+  })
+})

--- a/packages/zkpassport-utils/tsconfig.json
+++ b/packages/zkpassport-utils/tsconfig.json
@@ -11,5 +11,11 @@
     }
   },
   // "include" controls type-checking only; build output is controlled by tsup.config.ts entry points
-  "include": ["src/**/*.ts", "tests/**/*.json", "tests/**/*.ts", "tsup.config.ts"]
+  "include": [
+    "src/**/*.ts",
+    "tests/**/*.json",
+    "tests/**/*.ts",
+    "conformance/*.json",
+    "tsup.config.ts"
+  ]
 }


### PR DESCRIPTION
## What

`@zkpassport/utils` now ships `conformance/vectors.json`: reference vectors (policy params + expected Poseidon2 commitment) for the parameter-commitment scheme, plus `tests/conformance.test.ts` holding this package's own functions to them.

## Why

The scheme has multiple independent implementations: this package's TS functions, the circuits repo's Noir libs, and downstream verifiers (e.g. zkpassport.nr on Aztec, which currently hand-authors its own anchors). Nothing enforces agreement between them today beyond per-consumer harnesses. Publishing the vectors with each release turns them into a versioned contract any implementation can test against instead of authoring its own.

## Blast radius

Additive only: a data file added to `files`, one test, a tsconfig include line. No API or source changes; existing consumers are unaffected.