### PR TITLE
feat(utils): Add a sanctions conformance vector

### DIFF
--- a/packages/zkpassport-utils/conformance/vectors.json
+++ b/packages/zkpassport-utils/conformance/vectors.json
@@ -18,6 +18,15 @@
       "commitment": "0x1b6d3f9e55b8456c4baf5f21d14e5e425b6d23df44e3067f561b0ab41cf7b59f"
     },
     {
+      "name": "sanctions_strict",
+      "proofType": "sanctions",
+      "params": {
+        "root": "0x2233445566778899001122334455667788990011223344556677889900112233",
+        "isStrict": true
+      },
+      "commitment": "0x2606e9e340f2e14080b1ff4ab95a1182129793c30adb8326e1d6073aef4f5a4d"
+    },
+    {
       "name": "bind_user_address",
       "proofType": "bind",
       "params": {

--- a/packages/zkpassport-utils/src/circuits/sanctions/sanctions.ts
+++ b/packages/zkpassport-utils/src/circuits/sanctions/sanctions.ts
@@ -132,14 +132,29 @@ export class SanctionsBuilder {
 
   async getSanctionsParameterCommitment(isStrict: boolean): Promise<bigint> {
     const rootHash = this.getRootHash()
-    const hash = await poseidon2HashAsync([
-      BigInt(ProofType.SANCTIONS_EXCLUSION),
-      BigInt(ProofTypeLength[ProofType.SANCTIONS_EXCLUSION].standard),
+    return getSanctionsParameterCommitmentFromRoot(
       BigInt(`0x${rootHash.toString("hex")}`),
-      isStrict ? 1n : 0n,
-    ])
-    return hash
+      isStrict,
+    )
   }
+}
+
+/**
+ * Get the parameter commitment for the sanctions exclusion proof from a given tree root.
+ * @param root - The sanctions merkle tree root.
+ * @param isStrict - Whether the strict check is enforced.
+ * @returns The parameter commitment.
+ */
+export async function getSanctionsParameterCommitmentFromRoot(
+  root: bigint,
+  isStrict: boolean,
+): Promise<bigint> {
+  return poseidon2HashAsync([
+    BigInt(ProofType.SANCTIONS_EXCLUSION),
+    BigInt(ProofTypeLength[ProofType.SANCTIONS_EXCLUSION].standard),
+    root,
+    isStrict ? 1n : 0n,
+  ])
 }
 
 function formatSanctionsProof(proof: SortedNonMembershipProof): CircuitSanctionsProof {

--- a/packages/zkpassport-utils/tests/conformance.test.ts
+++ b/packages/zkpassport-utils/tests/conformance.test.ts
@@ -6,6 +6,7 @@ import vectors from "../conformance/vectors.json"
 import { getAgeParameterCommitment } from "../src/circuits/age"
 import { formatBoundData, getBindParameterCommitment } from "../src/circuits/bind"
 import { getDiscloseParameterCommitment } from "../src/circuits/disclose"
+import { getSanctionsParameterCommitmentFromRoot } from "../src/circuits/sanctions/sanctions"
 
 type Vector = { name: string; proofType: string; params: Record<string, any>; commitment: string }
 const byType = Object.fromEntries((vectors.vectors as Vector[]).map((v) => [v.proofType, v]))
@@ -13,7 +14,12 @@ const hex = (b: bigint) => "0x" + b.toString(16).padStart(64, "0")
 
 describe("Conformance vectors", () => {
   test("every vector is checked here", () => {
-    expect(vectors.vectors.map((v) => v.proofType).sort()).toEqual(["age", "bind", "disclose"])
+    expect(vectors.vectors.map((v) => v.proofType).sort()).toEqual([
+      "age",
+      "bind",
+      "disclose",
+      "sanctions",
+    ])
   })
 
   test("age", async () => {
@@ -31,6 +37,15 @@ describe("Conformance vectors", () => {
       disclosed[mrzIndex] = params.disclosedText.charCodeAt(i)
     })
     const result = await getDiscloseParameterCommitment(mask, disclosed)
+    expect(hex(result)).toEqual(commitment)
+  })
+
+  test("sanctions", async () => {
+    const { params, commitment } = byType.sanctions
+    const result = await getSanctionsParameterCommitmentFromRoot(
+      BigInt(params.root),
+      params.isStrict,
+    )
     expect(hex(result)).toEqual(commitment)
   })
 


### PR DESCRIPTION
## What

Adds a `sanctions` entry to `conformance/vectors.json` (strict variant over a synthetic every-byte-distinct root) and extracts `getSanctionsParameterCommitmentFromRoot(root, isStrict)` from `SanctionsBuilder` so the commitment can be computed from a bare root — the builder method now delegates to it. `tests/conformance.test.ts` holds the new function to the vector.

## Why

Follow-up to #277: sanctions was the one commitment without a vector, because the only SDK entry point was an instance method bound to the downloaded sanctions tree. With the root parameterized, downstream verifiers (zkpassport.nr's `sanctions_commitment`, currently untested against TS) can be held to the same published vector.

## Blast radius

Additive: one new exported function (the existing method's behavior is unchanged — verified by the existing sanctions tests), one vector, one test. Full package suite green (171 tests).
