### PR TITLE
fix(registry-sdk): Respect zero retry count

### DIFF
--- a/packages/registry-sdk/src/client.ts
+++ b/packages/registry-sdk/src/client.ts
@@ -143,7 +143,7 @@ export class RegistryClient {
       circuitManifestUrlGenerator || chainConfig?.circuitManifestUrlGenerator
     this.packagedCircuitUrlGenerator =
       packagedCircuitUrlGenerator || chainConfig?.packagedCircuitUrlGenerator
-    this.retryCount = retryCount || DEFAULT_RETRY_COUNT
+    this.retryCount = retryCount ?? DEFAULT_RETRY_COUNT
   }
 
   /**

--- a/packages/registry-sdk/src/types.ts
+++ b/packages/registry-sdk/src/types.ts
@@ -41,7 +41,7 @@ export interface RegistryClientOptions {
   packagedCircuitUrlGenerator?: (chainId: number, hash: string, cid?: string) => string
 
   /**
-   * Number of retries for fetching data, default is 3
+   * Number of retries for fetching data. Set to 0 to disable retries; defaults to 3.
    */
   retryCount?: number
 }

--- a/packages/registry-sdk/tests/retry.test.ts
+++ b/packages/registry-sdk/tests/retry.test.ts
@@ -159,6 +159,30 @@ describe("Retry Logic", () => {
   })
 
   describe("Custom Retry Count", () => {
+    it("should respect retryCount of 0", async () => {
+      clock = FakeTimers.install()
+
+      const registryWithoutRetries = new RegistryClient({
+        chainId: 31337,
+        rpcUrl: MOCK_RPC_URL,
+        rootRegistry: "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+        registryHelper: "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
+        retryCount: 0,
+      })
+
+      globalThis.fetch = (async (_: RequestInfo | URL): Promise<Response> => {
+        attemptCount++
+        throw new TypeError("Network error")
+      }) as typeof fetch
+
+      const certPromise = registryWithoutRetries.getCertificates(MOCK_ROOT, { validate: false })
+
+      const [, error] = await Promise.all([clock.runAllAsync(), certPromise.catch((e) => e)])
+
+      expect(error).toBeInstanceOf(TypeError)
+      expect(attemptCount).toBe(1) // Initial attempt only
+    })
+
     it("should respect retryCount of 1", async () => {
       clock = FakeTimers.install()
 


### PR DESCRIPTION
## Summary

`RegistryClient` treated an explicit `retryCount: 0` as falsy and replaced it with the default of 3. That made callers who disabled retries perform four network attempts instead of one.

This changes the fallback to nullish coalescing, documents the zero-retry behavior, and adds a regression test that exercises the real fetch path.

## Checks

- `bun test packages/registry-sdk/tests/retry.test.ts` — 8 passed
- registry package build
- Prettier on changed files
- ESLint on changed files
- `git diff --check`

The regression test failed before the fix with one expected attempt and four actual attempts. The wider registry SDK suite also starts Anvil integration tests; that part cannot run in this environment because the `anvil` binary is not installed. The retry suite itself passes in full.