### PR TITLE
feat(workspace): Gate attest-demo behind optional basic auth

### DIFF
--- a/packages/attest-contracts/deployments/11155111.json
+++ b/packages/attest-contracts/deployments/11155111.json
@@ -1,0 +1,6 @@
+{
+  "address": "0x2a615a175439b9eb0004b924aBdD2B4c7a871f11",
+  "deployed_at": 1788424716,
+  "deployed_block": 11625471,
+  "root_verifier": "0x1D000001000EFD9a6371f4d90bB8920D5431c0D8"
+}

--- a/packages/attest-demo/lib/basic-auth.ts
+++ b/packages/attest-demo/lib/basic-auth.ts
@@ -1,0 +1,23 @@
+/**
+ * Checks an HTTP Basic Authorization header against configured credentials.
+ *
+ * @param authorizationHeader The request's Authorization header, or null.
+ * @param credentials Expected "user:pass" pair; when unset or empty the gate
+ *   is disabled and every request is allowed.
+ */
+export function checkBasicAuth(
+  authorizationHeader: string | null,
+  credentials: string | undefined,
+): boolean {
+  if (!credentials) {
+    return true
+  }
+  if (!authorizationHeader) {
+    return false
+  }
+  const [scheme, token, ...rest] = authorizationHeader.split(" ")
+  if (!scheme || !token || rest.length > 0 || scheme.toLowerCase() !== "basic") {
+    return false
+  }
+  return token === btoa(credentials)
+}

--- a/packages/attest-demo/middleware.ts
+++ b/packages/attest-demo/middleware.ts
@@ -1,0 +1,16 @@
+import { NextResponse, type NextRequest } from "next/server"
+import { checkBasicAuth } from "./lib/basic-auth"
+
+export function middleware(request: NextRequest) {
+  const allowed = checkBasicAuth(
+    request.headers.get("authorization"),
+    process.env.BASIC_AUTH_CREDENTIALS,
+  )
+  if (allowed) {
+    return NextResponse.next()
+  }
+  return new NextResponse("Authentication required", {
+    status: 401,
+    headers: { "WWW-Authenticate": 'Basic realm="attest-demo"' },
+  })
+}

--- a/packages/attest-demo/tests/basic-auth.test.ts
+++ b/packages/attest-demo/tests/basic-auth.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test"
+import { checkBasicAuth } from "../lib/basic-auth"
+
+const CREDENTIALS = "demo:hunter2"
+const VALID_HEADER = `Basic ${btoa(CREDENTIALS)}`
+
+describe("checkBasicAuth", () => {
+  test("allows every request when no credentials are configured", () => {
+    expect(checkBasicAuth(null, undefined)).toBe(true)
+    expect(checkBasicAuth(null, "")).toBe(true)
+    expect(checkBasicAuth(VALID_HEADER, undefined)).toBe(true)
+  })
+
+  test("allows a request with the matching header", () => {
+    expect(checkBasicAuth(VALID_HEADER, CREDENTIALS)).toBe(true)
+  })
+
+  test("accepts a case-insensitive scheme", () => {
+    expect(checkBasicAuth(`basic ${btoa(CREDENTIALS)}`, CREDENTIALS)).toBe(true)
+  })
+
+  test("rejects a missing header", () => {
+    expect(checkBasicAuth(null, CREDENTIALS)).toBe(false)
+  })
+
+  test("rejects wrong credentials", () => {
+    expect(checkBasicAuth(`Basic ${btoa("demo:wrong")}`, CREDENTIALS)).toBe(false)
+  })
+
+  test("rejects a non-basic scheme", () => {
+    expect(checkBasicAuth(`Bearer ${btoa(CREDENTIALS)}`, CREDENTIALS)).toBe(false)
+  })
+
+  test("rejects a malformed header", () => {
+    expect(checkBasicAuth("Basic", CREDENTIALS)).toBe(false)
+    expect(checkBasicAuth("not-a-header", CREDENTIALS)).toBe(false)
+  })
+})


### PR DESCRIPTION
Stacked on #267.

Adds an optional HTTP basic-auth gate to attest-demo so public demo deployments can be protected from spam. A Next.js middleware answers 401 with `WWW-Authenticate: Basic` unless the Authorization header matches `BASIC_AUTH_CREDENTIALS` (`user:pass`). The gate is disabled when the variable is unset, so local dev and CI need no setup.

- `lib/basic-auth.ts`: pure header check (unit-tested: scheme case-insensitivity, malformed headers, wrong creds, disabled gate)
- `middleware.ts`: wires it to every route
- Verified against a production build: 401 without/with wrong creds, 200 with correct creds, 200 when the variable is unset
