### PR TITLE
fix(workspace): Send the isolation header from the deployed verification popup

### DIFF
--- a/packages/verify-popup/README.md
+++ b/packages/verify-popup/README.md
@@ -16,7 +16,8 @@ Point the button at it with `popupUrl="http://localhost:5173"`.
 ## Deployment
 
 Build with `bun run build` (static output in `dist/`). The host MUST send this
-response header on the page:
+response header on the page and on every asset it loads (the `bb.js` workers
+need it too), which `vercel.json` does for the Vercel deployment:
 
 ```
 Document-Isolation-Policy: isolate-and-credentialless

--- a/packages/verify-popup/vercel.json
+++ b/packages/verify-popup/vercel.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Document-Isolation-Policy",
+          "value": "isolate-and-credentialless"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The hosted verification popup was missing a response header that browsers require before granting a page more than one CPU core, so proof generation ran single-threaded and slower than it should. It was already set for local development, just never on the deployed site.

### Key changes
- `vercel.json` sends `Document-Isolation-Policy` for the popup page and its assets

### Rollout
No package release needed; applies on the next production deploy from `main`.
