### PR TITLE
feat(sdk): Allow a request to override a policy's scope

### DIFF
--- a/packages/zkpassport-sdk/src/dashboard-api.ts
+++ b/packages/zkpassport-sdk/src/dashboard-api.ts
@@ -9,6 +9,7 @@ export async function submitProof({
   query,
   queryResult,
   scope,
+  policyId,
   requestId,
 }: {
   domain: string
@@ -16,6 +17,7 @@ export async function submitProof({
   query: Query
   queryResult: QueryResult
   scope: string | undefined
+  policyId: string | undefined
   requestId: string | undefined
 }) {
   const payload = proofs.map((p) => ({
@@ -37,6 +39,7 @@ export async function submitProof({
         query,
         queryResult,
         scope,
+        policyId,
         sdkVersion: VERSION,
         requestId,
       }),

--- a/packages/zkpassport-sdk/src/index.ts
+++ b/packages/zkpassport-sdk/src/index.ts
@@ -245,6 +245,7 @@ export class ZKPassport {
         query: this.topicToConfig[topic],
         queryResult: result,
         scope: this.topicToService[topic]?.scope,
+        policyId: this.topicToPolicy[topic]?.id,
         requestId: this.topicToPublicKey[topic],
       })
     }
@@ -520,13 +521,14 @@ export class ZKPassport {
         // later .bind() writes into it
         const { bind: _, ...policyQuery } = policy.query
         this.topicToConfig[topic] = policyQuery
-        // Policy locks scope; caller's purpose still wins when provided.
         const svc = this.topicToService[topic]
         if (svc) {
           if (!this.topicToCallerPurpose[topic]) {
             svc.purpose = policy.purpose || DEFAULT_PURPOSE
           }
-          svc.scope = policy.id
+          if (!svc.scope) {
+            svc.scope = policy.id
+          }
         }
         this.topicToPolicy[topic] = {
           id: policy.id,
@@ -682,11 +684,11 @@ export class ZKPassport {
 
   /**
    * @notice Create a new request. To apply a policy, chain `.policy('<id>')` on
-   * the returned builder; a policy locks the query and scope.
+   * the returned builder; a policy locks the query.
    * @param name Your service name. Defaults to the dashboard branding, then the domain.
    * @param logo Your service logo. Defaults to the dashboard branding.
    * @param purpose Explanation shown to the user. Defaults to the policy's purpose (if any), then a generic message.
-   * @param scope Use-case scope (drives the nullifier). Defaults to the domain. Locked by `.policy()` (to the policy id).
+   * @param scope Use-case scope (drives the nullifier). Defaults to the policy id (if any), then the domain.
    * @param projectID The project ID of your service
    * @param validity How many seconds ago the proof checking the expiry date of the ID should have been generated
    * @param mode The proof mode (e.g. "fast" / "compressed").

--- a/packages/zkpassport-sdk/src/types.ts
+++ b/packages/zkpassport-sdk/src/types.ts
@@ -323,9 +323,9 @@ export type QueryBuilder<T extends "online" | "offline" = "online"> = {
   // set so far. Used by the hosted popup.
   raw: (query: Query) => QueryBuilder<T>
   /**
-   * Applies an immutable policy fetched from the dashboard. The policy's query,
-   * purpose and scope are locked; combining with builder methods (except
-   * `.bind()`, which may follow it) or calling twice throws.
+   * Applies a policy fetched from the dashboard. The policy's query is locked, and its
+   * purpose and scope are used unless the request sets its own. Combining with builder
+   * methods (except `.bind()`, which may follow it) or calling twice throws.
    * @param id The policy id (e.g. `'pol_xyz'`).
    */
   policy: (id: string) => QueryBuilder<T>

--- a/packages/zkpassport-sdk/tests/proof-submission.test.ts
+++ b/packages/zkpassport-sdk/tests/proof-submission.test.ts
@@ -79,6 +79,7 @@ describe("Proof submission", () => {
     expect(body).toMatchObject({
       domain: "localhost",
       scope: "pol_xyz",
+      policyId: "pol_xyz",
       query: { age: { gte: 18 } },
       // The bridge public key (URL `p=`), not the topic — links the proof to its activity row.
       requestId: "04deadbeefpubkey",
@@ -86,6 +87,17 @@ describe("Proof submission", () => {
     expect(body.uniqueIdentifier).toBeUndefined()
     expect(body.proofs).toHaveLength(1)
     expect(body.proofs[0]).toMatchObject({ proof: "0xdeadbeef", name: "outer_xyz" })
+  })
+
+  test("reports the policy id when the caller overrode the scope", async () => {
+    const zk = new ZKPassport("localhost")
+    const { topic } = primeForHandleResult(zk)
+    ;(zk as any).topicToService[topic].scope = "exchange-signup"
+
+    await (zk as any).handleResult(topic)
+
+    const body = JSON.parse(fetchedBodies[0])
+    expect(body).toMatchObject({ scope: "exchange-signup", policyId: "pol_xyz" })
   })
 
   test("does not submit for a self-serve request (no policy)", async () => {

--- a/packages/zkpassport-sdk/tests/query-builder.test.ts
+++ b/packages/zkpassport-sdk/tests/query-builder.test.ts
@@ -572,14 +572,12 @@ describe("Policy-driven requests", () => {
     const service = JSON.parse(Buffer.from(servicePart, "base64").toString())
     expect(service.name).toBe("White Label")
     expect(service.logo).toBe("https://white.example/logo.png")
-    // purpose/scope are locked by the policy
+    // purpose/scope still come from the policy
     expect(service.purpose).toBe("Policy purpose")
     expect(service.scope).toBe("pol_xyz")
   })
 
-  test("policy locks scope but caller's purpose still wins", async () => {
-    // scope drives the nullifier, so callers can't change it once a policy is bound.
-    // purpose is user-facing copy, so callers can override the policy default.
+  test("caller's purpose and scope win over the policy", async () => {
     const queryBuilder = (
       await zkPassport.request({
         purpose: "Caller-supplied purpose",
@@ -591,7 +589,7 @@ describe("Policy-driven requests", () => {
     const servicePart = new URL(result.url).searchParams.get("s")!
     const service = JSON.parse(Buffer.from(servicePart, "base64").toString())
     expect(service.purpose).toBe("Caller-supplied purpose")
-    expect(service.scope).toBe("pol_xyz")
+    expect(service.scope).toBe("caller-supplied-scope")
   })
 
   test("self-serve callers get sensible defaults when no fields are supplied", async () => {


### PR DESCRIPTION
Moving a live integration onto a dashboard policy used to change the scope, and the scope decides each user's unique identifier — so stored ids stopped matching and returning users looked brand new. A request can now keep its own scope while using a policy.

### Key changes

- A `scope` passed to `request()` wins over the policy id.
- Proof submissions name their policy directly, so the dashboard no longer reads it out of the scope.

### Related PRs

- zkpassport/zkpassport-customer-dashboard#277

### Rollout order

Deploy the dashboard API first (related PR, plus its `0.17` version-registry entry), then publish `@zkpassport/sdk` `0.17`.