### PR TITLE
chore(sdk): Bump @obsidion/bridge to 0.12.2

### DIFF
--- a/packages/zkpassport-sdk/package.json
+++ b/packages/zkpassport-sdk/package.json
@@ -72,7 +72,7 @@
     "@noble/hashes": "^2.0.1",
     "@noble/secp256k1": "^2.2.3",
     "@noir-lang/noir_js": "1.0.0-beta.22",
-    "@obsidion/bridge": "^0.11.2",
+    "@obsidion/bridge": "^0.12.2",
     "@zkpassport/registry": "workspace:*",
     "@zkpassport/utils": "workspace:*",
     "buffer": "^6.0.3",


### PR DESCRIPTION
Picks up the `@obsidion/bridge` fix for browser tabs that lost their bridge connection and never got it back (e.g. a phone switching to the ZKPassport app and back). No SDK code changes: the bridge library owns the reconnect logic.

### Key changes
- `@obsidion/bridge` from `^0.11.2` to `^0.12.2`

### Related PRs
- obsidionlabs/obsidion-bridge#19

### Rollout order
1. Merge and publish `@obsidion/bridge` `0.12.2`
2. Update the lockfile here, then merge
