### PR TITLE
feat(ui): Show a connection lost state and cancel stale requests

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -126,6 +126,7 @@
       "name": "@zkpassport/ui",
       "version": "0.17.0-beta.2",
       "devDependencies": {
+        "@happy-dom/global-registrator": "^20.14.0",
         "@types/qrcode": "^1.5.5",
         "@types/react": "^18.3.0",
         "@types/react-dom": "^18.3.0",
@@ -299,6 +300,8 @@
     "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.8", "", { "dependencies": { "@floating-ui/dom": "^1.7.6" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
+
+    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.14.0", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.14.0" } }, "sha512-Xn0kdkaA1eHOaFFopr+YQ37sPNTZ3JScpUMz3j4rIsn1Nneqoh94z79iW23Ej0Ytt99+LlFr4JrSDd6ow9c7MQ=="],
 
     "@humanwhocodes/config-array": ["@humanwhocodes/config-array@0.13.0", "", { "dependencies": { "@humanwhocodes/object-schema": "^2.0.3", "debug": "^4.3.1", "minimatch": "^3.0.5" } }, "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw=="],
 
@@ -632,6 +635,8 @@
 
     "@types/stack-utils": ["@types/stack-utils@2.0.3", "", {}, "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="],
 
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@types/yargs": ["@types/yargs@17.0.35", "", { "dependencies": { "@types/yargs-parser": "*" } }, "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg=="],
@@ -792,6 +797,8 @@
 
     "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
+    "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
+
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bundle-require": ["bundle-require@5.1.0", "", { "dependencies": { "load-tsconfig": "^0.2.3" }, "peerDependencies": { "esbuild": ">=0.18" } }, "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA=="],
@@ -940,7 +947,7 @@
 
     "emojilib": ["emojilib@2.4.0", "", {}, "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw=="],
 
-    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
 
@@ -1081,6 +1088,8 @@
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "graphemer": ["graphemer@1.4.0", "", {}, "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="],
+
+    "happy-dom": ["happy-dom@20.14.0", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-4bRh1KzRvKDnFNTlLhzT1RZTpkKhQbQDl9j+7GXszWsvuspYdo29k6OHRf4PwiM6oLb8r/pMWeYiJjkfod5AvQ=="],
 
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
 
@@ -1648,6 +1657,8 @@
 
     "vite": ["vite@6.4.3", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A=="],
 
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "which-boxed-primitive": ["which-boxed-primitive@1.1.1", "", { "dependencies": { "is-bigint": "^1.1.0", "is-boolean-object": "^1.2.1", "is-number-object": "^1.1.1", "is-string": "^1.1.1", "is-symbol": "^1.1.1" } }, "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA=="],
@@ -1727,6 +1738,8 @@
     "cli-highlight/yargs": ["yargs@16.2.0", "", { "dependencies": { "cliui": "^7.0.2", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.0", "y18n": "^5.0.5", "yargs-parser": "^20.2.2" } }, "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw=="],
 
     "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
+
+    "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 

--- a/packages/zkpassport-sdk/package.json
+++ b/packages/zkpassport-sdk/package.json
@@ -72,7 +72,7 @@
     "@noble/hashes": "^2.0.1",
     "@noble/secp256k1": "^2.2.3",
     "@noir-lang/noir_js": "1.0.0-beta.22",
-    "@obsidion/bridge": "^0.11.2",
+    "@obsidion/bridge": "^0.12.2",
     "@zkpassport/registry": "workspace:*",
     "@zkpassport/utils": "workspace:*",
     "buffer": "^6.0.3",

--- a/packages/zkpassport-sdk/package.json
+++ b/packages/zkpassport-sdk/package.json
@@ -72,7 +72,7 @@
     "@noble/hashes": "^2.0.1",
     "@noble/secp256k1": "^2.2.3",
     "@noir-lang/noir_js": "1.0.0-beta.22",
-    "@obsidion/bridge": "^0.12.2",
+    "@obsidion/bridge": "^0.12.3",
     "@zkpassport/registry": "workspace:*",
     "@zkpassport/utils": "workspace:*",
     "buffer": "^6.0.3",

--- a/packages/zkpassport-sdk/package.json
+++ b/packages/zkpassport-sdk/package.json
@@ -72,7 +72,7 @@
     "@noble/hashes": "^2.0.1",
     "@noble/secp256k1": "^2.2.3",
     "@noir-lang/noir_js": "1.0.0-beta.22",
-    "@obsidion/bridge": "^0.12.3",
+    "@obsidion/bridge": "^0.12.2",
     "@zkpassport/registry": "workspace:*",
     "@zkpassport/utils": "workspace:*",
     "buffer": "^6.0.3",

--- a/packages/zkpassport-sdk/src/index.ts
+++ b/packages/zkpassport-sdk/src/index.ts
@@ -800,8 +800,8 @@ export class ZKPassport {
       await Promise.all(this.onBridgeConnectCallbacks[topic].map((callback) => callback()))
     })
     bridge.onDisconnect(async (event) => {
-      logger.debug("Bridge disconnected, will reconnect:", event.willReconnect)
       if (event.wasIntentionalClose || event.willReconnect) return
+      logger.debug("Bridge connection lost")
       await Promise.all(this.onBridgeConnectionLostCallbacks[topic].map((callback) => callback()))
     })
     bridge.onSecureChannelEstablished(async () => {

--- a/packages/zkpassport-sdk/src/index.ts
+++ b/packages/zkpassport-sdk/src/index.ts
@@ -165,6 +165,7 @@ export class ZKPassport {
   private onRequestReceivedCallbacks: Record<string, Array<() => void>> = {}
   private onGeneratingProofCallbacks: Record<string, Array<(topic: string) => void>> = {}
   private onBridgeConnectCallbacks: Record<string, Array<() => void>> = {}
+  private onBridgeConnectionLostCallbacks: Record<string, Array<() => void>> = {}
   private onProofGeneratedCallbacks: Record<string, Array<(proof: ProofResult) => void>> = {}
   private onSuccessCallbacks: Record<
     string,
@@ -578,6 +579,8 @@ export class ZKPassport {
             this.onGeneratingProofCallbacks[topic].push(callback),
           onBridgeConnect: (callback: () => void) =>
             this.onBridgeConnectCallbacks[topic].push(callback),
+          onBridgeConnectionLost: (callback: () => void) =>
+            this.onBridgeConnectionLostCallbacks[topic].push(callback),
           onProofGenerated: (callback: (proof: ProofResult) => void) =>
             this.onProofGeneratedCallbacks[topic].push(callback),
           onSuccess: (callback: (response: RequestSuccess) => OnSuccessVerdict) =>
@@ -780,6 +783,7 @@ export class ZKPassport {
     this.onRequestReceivedCallbacks[topic] = []
     this.onGeneratingProofCallbacks[topic] = []
     this.onBridgeConnectCallbacks[topic] = []
+    this.onBridgeConnectionLostCallbacks[topic] = []
     this.onProofGeneratedCallbacks[topic] = []
     this.onSuccessCallbacks[topic] = []
     this.onResultCallbacks[topic] = []
@@ -794,6 +798,11 @@ export class ZKPassport {
       logger.debug("Bridge connected")
       logger.debug("Is reconnection:", reconnection)
       await Promise.all(this.onBridgeConnectCallbacks[topic].map((callback) => callback()))
+    })
+    bridge.onDisconnect(async (event) => {
+      logger.debug("Bridge disconnected, will reconnect:", event.willReconnect)
+      if (event.wasIntentionalClose || event.willReconnect) return
+      await Promise.all(this.onBridgeConnectionLostCallbacks[topic].map((callback) => callback()))
     })
     bridge.onSecureChannelEstablished(async () => {
       logger.debug("Secure channel established")
@@ -1147,6 +1156,7 @@ export class ZKPassport {
     this.onRequestReceivedCallbacks[requestId] = []
     this.onGeneratingProofCallbacks[requestId] = []
     this.onBridgeConnectCallbacks[requestId] = []
+    this.onBridgeConnectionLostCallbacks[requestId] = []
     this.onProofGeneratedCallbacks[requestId] = []
     this.onRejectCallbacks[requestId] = []
     this.onErrorCallbacks[requestId] = []

--- a/packages/zkpassport-sdk/src/types.ts
+++ b/packages/zkpassport-sdk/src/types.ts
@@ -154,9 +154,7 @@ export type QueryBuilderResult = {
   onBridgeConnect: (callback: () => void) => void
   /**
    * Called when the connection to the bridge is lost and the SDK has stopped
-   * trying to reconnect on its own. The QR code will not work until the
-   * connection comes back (e.g. the page becomes visible again) or the request
-   * is recreated.
+   * trying to reconnect on its own. A later `onBridgeConnect` means it came back.
    */
   onBridgeConnectionLost: (callback: () => void) => void
   /**

--- a/packages/zkpassport-sdk/src/types.ts
+++ b/packages/zkpassport-sdk/src/types.ts
@@ -153,6 +153,13 @@ export type QueryBuilderResult = {
    */
   onBridgeConnect: (callback: () => void) => void
   /**
+   * Called when the connection to the bridge is lost and the SDK has stopped
+   * trying to reconnect on its own. The QR code will not work until the
+   * connection comes back (e.g. the page becomes visible again) or the request
+   * is recreated.
+   */
+  onBridgeConnectionLost: (callback: () => void) => void
+  /**
    * Called when the user has generated a proof.
    *
    * There is a minimum of 4 proofs, but there can be more depending

--- a/packages/zkpassport-sdk/tests/bridge-callbacks.test.ts
+++ b/packages/zkpassport-sdk/tests/bridge-callbacks.test.ts
@@ -1,0 +1,79 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { BridgeDisconnectedEvent } from "@obsidion/bridge"
+import { ZKPassport } from "../src/index"
+
+describe("Bridge connection callbacks", () => {
+  let originalFetch: typeof globalThis.fetch
+
+  beforeEach(() => {
+    // request() fetches the dashboard config best-effort; stub so tests stay offline.
+    originalFetch = globalThis.fetch
+    globalThis.fetch = (async () =>
+      new Response("{}", {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      })) as unknown as typeof globalThis.fetch
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  async function createRequest() {
+    const zkPassport = new ZKPassport("localhost")
+    const queryBuilder = await zkPassport.request({ name: "Test App", purpose: "Testing" })
+    const request = queryBuilder.done()
+    const bridge = (zkPassport as any).topicToBridge[request.requestId]
+    // Deliver a disconnect through the same listener the SDK registered on the bridge
+    const disconnect = (options: { wasIntentionalClose: boolean; willReconnect: boolean }) =>
+      bridge.connection.emit(
+        "disconnected",
+        new BridgeDisconnectedEvent({
+          code: 1006,
+          reason: "",
+          wasConnected: true,
+          event: {} as CloseEvent,
+          ...options,
+        }),
+      )
+    return { zkPassport, request, disconnect }
+  }
+
+  test("reports a lost connection only once the bridge stops reconnecting", async () => {
+    const { request, disconnect } = await createRequest()
+    let lost = 0
+    request.onBridgeConnectionLost(() => {
+      lost++
+    })
+
+    await disconnect({ wasIntentionalClose: false, willReconnect: true })
+    expect(lost).toBe(0)
+
+    await disconnect({ wasIntentionalClose: false, willReconnect: false })
+    expect(lost).toBe(1)
+  })
+
+  test("does not report a lost connection for an intentional close", async () => {
+    const { request, disconnect } = await createRequest()
+    let lost = 0
+    request.onBridgeConnectionLost(() => {
+      lost++
+    })
+
+    await disconnect({ wasIntentionalClose: true, willReconnect: false })
+    expect(lost).toBe(0)
+  })
+
+  test("cancelRequest clears the callback", async () => {
+    const { zkPassport, request, disconnect } = await createRequest()
+    let lost = 0
+    request.onBridgeConnectionLost(() => {
+      lost++
+    })
+
+    zkPassport.cancelRequest(request.requestId)
+    await disconnect({ wasIntentionalClose: false, willReconnect: false })
+    expect(lost).toBe(0)
+  })
+})

--- a/packages/zkpassport-sdk/tests/bridge-callbacks.test.ts
+++ b/packages/zkpassport-sdk/tests/bridge-callbacks.test.ts
@@ -25,7 +25,7 @@ describe("Bridge connection callbacks", () => {
     const queryBuilder = await zkPassport.request({ name: "Test App", purpose: "Testing" })
     const request = queryBuilder.done()
     const bridge = (zkPassport as any).topicToBridge[request.requestId]
-    // Deliver a disconnect through the same listener the SDK registered on the bridge
+    // No websocket mock here, so fire the bridge's own disconnected event directly
     const disconnect = (options: { wasIntentionalClose: boolean; willReconnect: boolean }) =>
       bridge.connection.emit(
         "disconnected",

--- a/packages/zkpassport-ui/package.json
+++ b/packages/zkpassport-ui/package.json
@@ -95,6 +95,7 @@
     }
   },
   "devDependencies": {
+    "@happy-dom/global-registrator": "^20.14.0",
     "@types/qrcode": "^1.5.5",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",

--- a/packages/zkpassport-ui/src/card.tsx
+++ b/packages/zkpassport-ui/src/card.tsx
@@ -65,7 +65,7 @@ export function Card({ options, controlRef }: CardProps) {
     state === "scanned" || state === "generating" || state === "success" || state === "error"
   const hasFacematch = !!query?.facematch
   const overlayCaption = getOverlayCaption(state)
-  const canRestart = state === "waiting" || state === "scanned"
+  const canRestart = state === "waiting" || state === "scanned" || state === "disconnected"
   // Phones can't scan their own screen: lead with the universal link into the
   // app; the QR stays behind a toggle for cross-device flows
   const [qrRevealed, setQrRevealed] = useState(false)
@@ -195,7 +195,7 @@ export function Card({ options, controlRef }: CardProps) {
             </div>
           ) : null}
 
-          {state === "error" ? (
+          {state === "error" || state === "disconnected" ? (
             <div className="zkp-result-actions">
               <button type="button" className="zkp-retry" onClick={retry}>
                 Try again
@@ -308,6 +308,8 @@ function getOverlayCaption(state: CardState): string {
       return "Request complete"
     case "error":
       return "Something went wrong"
+    case "disconnected":
+      return "Connection lost"
     default:
       return ""
   }
@@ -424,7 +426,7 @@ function QrSlot({
           {state === "success" ? (
             <div className="zkp-check" dangerouslySetInnerHTML={{ __html: ICON_CHECK }} />
           ) : null}
-          {state === "error" ? (
+          {state === "error" || state === "disconnected" ? (
             <div className="zkp-error-icon" dangerouslySetInnerHTML={{ __html: ICON_ERROR }} />
           ) : null}
         </div>

--- a/packages/zkpassport-ui/src/card.tsx
+++ b/packages/zkpassport-ui/src/card.tsx
@@ -65,7 +65,7 @@ export function Card({ options, controlRef }: CardProps) {
     state === "scanned" || state === "generating" || state === "success" || state === "error"
   const hasFacematch = !!query?.facematch
   const overlayCaption = getOverlayCaption(state)
-  const canRestart = state === "waiting" || state === "scanned" || state === "disconnected"
+  const canRestart = state === "waiting" || state === "scanned"
   // Phones can't scan their own screen: lead with the universal link into the
   // app; the QR stays behind a toggle for cross-device flows
   const [qrRevealed, setQrRevealed] = useState(false)

--- a/packages/zkpassport-ui/src/styles.css
+++ b/packages/zkpassport-ui/src/styles.css
@@ -255,14 +255,16 @@
   .zkp-qr-slot[data-state="local-proving"] .zkp-qr,
   .zkp-qr-slot[data-state="save-offer"] .zkp-qr,
   .zkp-qr-slot[data-state="success"] .zkp-qr,
-  .zkp-qr-slot[data-state="error"] .zkp-qr {
+  .zkp-qr-slot[data-state="error"] .zkp-qr,
+  .zkp-qr-slot[data-state="disconnected"] .zkp-qr {
     opacity: 0.35;
   }
   .zkp-qr-slot[data-state="generating"] .zkp-qr-logo,
   .zkp-qr-slot[data-state="local-proving"] .zkp-qr-logo,
   .zkp-qr-slot[data-state="save-offer"] .zkp-qr-logo,
   .zkp-qr-slot[data-state="success"] .zkp-qr-logo,
-  .zkp-qr-slot[data-state="error"] .zkp-qr-logo {
+  .zkp-qr-slot[data-state="error"] .zkp-qr-logo,
+  .zkp-qr-slot[data-state="disconnected"] .zkp-qr-logo {
     opacity: 0;
   }
   .zkp-qr-slot[data-state="connecting"] .zkp-overlay,
@@ -271,7 +273,8 @@
   .zkp-qr-slot[data-state="local-proving"] .zkp-overlay,
   .zkp-qr-slot[data-state="save-offer"] .zkp-overlay,
   .zkp-qr-slot[data-state="success"] .zkp-overlay,
-  .zkp-qr-slot[data-state="error"] .zkp-overlay {
+  .zkp-qr-slot[data-state="error"] .zkp-overlay,
+  .zkp-qr-slot[data-state="disconnected"] .zkp-overlay {
     display: block;
   }
 

--- a/packages/zkpassport-ui/src/use-card.ts
+++ b/packages/zkpassport-ui/src/use-card.ts
@@ -50,7 +50,6 @@ export function useCard(options: ZKPassportQRCodeOptions): UseCard {
   const optionsRef = useRef(options)
   optionsRef.current = options
 
-  const requestRef = useRef<QueryBuilderResult | null>(null)
   // The bridge/QR-flow state, tracked even while the intro screen is showing so
   // Continue lands on the right screen
   const bridgeStateRef = useRef<CardState>("preparing")
@@ -76,7 +75,6 @@ export function useCard(options: ZKPassportQRCodeOptions): UseCard {
     setServiceName(null)
     setServiceLogo(null)
     setProofProgress({ received: 0, total: null })
-    requestRef.current = null
 
     const {
       domain: _domain,
@@ -106,10 +104,17 @@ export function useCard(options: ZKPassportQRCodeOptions): UseCard {
       safeCall(optionsRef.current.onReady)
     }
 
+    // Update the QR-flow state; while the intro is showing only the ref advances
+    const applyBridgeState = (next: CardState, forceShow = false) => {
+      bridgeStateRef.current = next
+      if (forceShow) introActiveRef.current = false
+      if (!introActiveRef.current) setState(next)
+    }
+
     // onError is the only way to tell the host app that something went wrong
     const fail = (summary: string, reason: unknown) => {
       logger.error(reason)
-      setState("error")
+      applyBridgeState("error", true)
       const detail = reason instanceof Error ? reason.message : String(reason)
       safeCall(optionsRef.current.onError, `${summary}: ${detail}`)
     }
@@ -125,30 +130,19 @@ export function useCard(options: ZKPassportQRCodeOptions): UseCard {
         }
       }
 
-    // Update the QR-flow state; while the intro is showing only the ref advances
-    const applyBridgeState = (next: CardState, forceShow = false) => {
-      bridgeStateRef.current = next
-      if (forceShow) introActiveRef.current = false
-      if (!introActiveRef.current) setState(next)
-    }
-
     sdkRef
       .current!.request({ ...sdkRequestArgs, verifierMode: "api" })
       .then((queryBuilder) => {
-        if (cancelled) {
-          // Restarted or unmounted while the request was still being set up: release its bridge
-          try {
-            sdkRef.current!.cancelRequest(queryBuilder.done().requestId)
-          } catch (reason) {
-            logger.error(reason)
-          }
-          return
-        }
         let request: QueryBuilderResult
         try {
           request = buildQuery(queryBuilder)
         } catch (reason) {
-          fail("Failed to build the verification query", reason)
+          if (!cancelled) fail("Failed to build the verification query", reason)
+          return
+        }
+        if (cancelled) {
+          // Restarted or unmounted while the request was still being set up: release its bridge
+          sdkRef.current!.cancelRequest(request.requestId)
           return
         }
 
@@ -156,18 +150,22 @@ export function useCard(options: ZKPassportQRCodeOptions): UseCard {
         let stateBeforeLoss: CardState = "waiting"
         request.onBridgeConnect(
           guard(() => {
-            const current = bridgeStateRef.current
-            if (current === "preparing" || current === "connecting") applyBridgeState("waiting")
-            else if (current === "disconnected") applyBridgeState(stateBeforeLoss)
+            const bridgeState = bridgeStateRef.current
+            if (bridgeState === "preparing" || bridgeState === "connecting") {
+              applyBridgeState("waiting")
+            } else if (bridgeState === "disconnected") {
+              applyBridgeState(stateBeforeLoss)
+            }
             fireReady()
             safeCall(optionsRef.current.onBridgeConnect)
           }),
         )
         request.onBridgeConnectionLost(
           guard(() => {
-            const current = bridgeStateRef.current
-            if (current === "success" || current === "error") return
-            stateBeforeLoss = current
+            const bridgeState = bridgeStateRef.current
+            const flowIsOver = bridgeState === "success" || bridgeState === "error"
+            if (flowIsOver || bridgeState === "disconnected") return
+            stateBeforeLoss = bridgeState
             applyBridgeState("disconnected")
           }),
         )
@@ -203,8 +201,7 @@ export function useCard(options: ZKPassportQRCodeOptions): UseCard {
             // returning false (e.g. when its backend did not verify the proofs)
             const finish = (next: "success" | "error") => {
               if (cancelled) return
-              introActiveRef.current = false
-              setState(next)
+              applyBridgeState(next, true)
             }
             let verdict: unknown
             try {
@@ -228,27 +225,23 @@ export function useCard(options: ZKPassportQRCodeOptions): UseCard {
         if (onResult) {
           request.onResult(
             guard((response) => {
-              introActiveRef.current = false
-              setState(response.verified ? "success" : "error")
+              applyBridgeState(response.verified ? "success" : "error", true)
               safeCall(optionsRef.current.onResult, response)
             }),
           )
         }
         request.onReject(
           guard(() => {
-            introActiveRef.current = false
-            setState("error")
+            applyBridgeState("error", true)
             safeCall(optionsRef.current.onReject)
           }),
         )
         request.onError(
           guard((message) => {
-            introActiveRef.current = false
-            setState("error")
+            applyBridgeState("error", true)
             safeCall(optionsRef.current.onError, message)
           }),
         )
-        requestRef.current = request
         setQuery(request.query)
         // Branding resolved by the SDK (options first, then dashboard config)
         try {
@@ -286,8 +279,8 @@ export function useCard(options: ZKPassportQRCodeOptions): UseCard {
 
     return () => {
       cancelled = true
-      // Close the old bridge so it stops pinging and the phone cannot join a stale request
-      if (requestRef.current) sdkRef.current!.cancelRequest(requestRef.current.requestId)
+      // Close this card's bridge so it stops pinging and the phone cannot join a stale request
+      sdkRef.current!.clearAllRequests()
     }
   }, [retryNonce])
 

--- a/packages/zkpassport-ui/src/use-card.ts
+++ b/packages/zkpassport-ui/src/use-card.ts
@@ -11,6 +11,7 @@ export type CardState =
   | "preparing"
   | "connecting"
   | "waiting"
+  | "disconnected"
   | "scanned"
   | "generating"
   | "success"
@@ -134,7 +135,15 @@ export function useCard(options: ZKPassportQRCodeOptions): UseCard {
     sdkRef
       .current!.request({ ...sdkRequestArgs, verifierMode: "api" })
       .then((queryBuilder) => {
-        if (cancelled) return
+        if (cancelled) {
+          // Restarted or unmounted while the request was still being set up: release its bridge
+          try {
+            sdkRef.current!.cancelRequest(queryBuilder.done().requestId)
+          } catch (reason) {
+            logger.error(reason)
+          }
+          return
+        }
         let request: QueryBuilderResult
         try {
           request = buildQuery(queryBuilder)
@@ -143,13 +152,23 @@ export function useCard(options: ZKPassportQRCodeOptions): UseCard {
           return
         }
 
+        // Where the flow was when the bridge gave up, to return there if it comes back
+        let stateBeforeLoss: CardState = "waiting"
         request.onBridgeConnect(
           guard(() => {
-            if (bridgeStateRef.current === "preparing" || bridgeStateRef.current === "connecting") {
-              applyBridgeState("waiting")
-            }
+            const current = bridgeStateRef.current
+            if (current === "preparing" || current === "connecting") applyBridgeState("waiting")
+            else if (current === "disconnected") applyBridgeState(stateBeforeLoss)
             fireReady()
             safeCall(optionsRef.current.onBridgeConnect)
+          }),
+        )
+        request.onBridgeConnectionLost(
+          guard(() => {
+            const current = bridgeStateRef.current
+            if (current === "success" || current === "error") return
+            stateBeforeLoss = current
+            applyBridgeState("disconnected")
           }),
         )
         request.onRequestReceived(
@@ -267,6 +286,8 @@ export function useCard(options: ZKPassportQRCodeOptions): UseCard {
 
     return () => {
       cancelled = true
+      // Close the old bridge so it stops pinging and the phone cannot join a stale request
+      if (requestRef.current) sdkRef.current!.cancelRequest(requestRef.current.requestId)
     }
   }, [retryNonce])
 

--- a/packages/zkpassport-ui/tests/card.test.ts
+++ b/packages/zkpassport-ui/tests/card.test.ts
@@ -4,6 +4,7 @@ import { ZKPassport } from "@zkpassport/sdk"
 import type { QueryBuilder, QueryBuilderResult } from "@zkpassport/sdk"
 import { mount } from "../src/vanilla"
 
+// Test-only DOM so preact can render the card under bun. A dev dependency, never shipped.
 beforeAll(() => {
   GlobalRegistrator.register()
 })

--- a/packages/zkpassport-ui/tests/card.test.ts
+++ b/packages/zkpassport-ui/tests/card.test.ts
@@ -1,0 +1,143 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { afterAll, afterEach, beforeAll, describe, expect, spyOn, test } from "bun:test"
+import { GlobalRegistrator } from "@happy-dom/global-registrator"
+import { ZKPassport } from "@zkpassport/sdk"
+import type { QueryBuilderResult } from "@zkpassport/sdk"
+import { mount } from "../src/vanilla"
+
+beforeAll(() => {
+  GlobalRegistrator.register()
+})
+
+afterAll(async () => {
+  await GlobalRegistrator.unregister()
+})
+
+type Listener = (...args: unknown[]) => void
+type FakeRequest = {
+  request: QueryBuilderResult
+  // Fire one of the SDK callbacks the card subscribed to
+  fire: (event: string, ...args: unknown[]) => void
+  // Resolve the pending sdk.request() call
+  release: () => void
+}
+
+function fakeRequest(id: string): FakeRequest {
+  const listeners: Record<string, Listener[]> = {}
+  const on = (name: string) => (callback: Listener) => {
+    ;(listeners[name] ??= []).push(callback)
+  }
+  const request = {
+    url: `https://zkpassport.id/r?t=${id}`,
+    query: {},
+    requestId: id,
+    onRequestReceived: on("onRequestReceived"),
+    onGeneratingProof: on("onGeneratingProof"),
+    onBridgeConnect: on("onBridgeConnect"),
+    onBridgeConnectionLost: on("onBridgeConnectionLost"),
+    onProofGenerated: on("onProofGenerated"),
+    onSuccess: on("onSuccess"),
+    onResult: on("onResult"),
+    onReject: on("onReject"),
+    onError: on("onError"),
+    isBridgeConnected: () => false,
+    requestReceived: () => false,
+  } as unknown as QueryBuilderResult
+  const fire = (name: string, ...args: unknown[]) => {
+    for (const callback of listeners[name] ?? []) callback(...args)
+  }
+  return { request, fire, release: () => {} }
+}
+
+const requests: FakeRequest[] = []
+const cancelled: string[] = []
+let holdRequests = false
+let spies: Array<{ mockRestore: () => void }> = []
+
+function stubSdk() {
+  requests.length = 0
+  cancelled.length = 0
+  holdRequests = false
+  spies = [
+    spyOn(ZKPassport.prototype, "request").mockImplementation((() => {
+      const fake = fakeRequest(`request-${requests.length + 1}`)
+      requests.push(fake)
+      return new Promise((resolve) => {
+        fake.release = () => resolve({ done: () => fake.request })
+        if (!holdRequests) fake.release()
+      })
+    }) as any),
+    spyOn(ZKPassport.prototype, "cancelRequest").mockImplementation((requestId: string) => {
+      cancelled.push(requestId)
+    }),
+  ]
+}
+
+afterEach(() => {
+  for (const spy of spies) spy.mockRestore()
+  document.body.innerHTML = ""
+})
+
+// Preact runs effects after the next frame, so poll instead of sleeping a fixed time
+async function waitFor(condition: () => boolean) {
+  for (let i = 0; i < 100; i++) {
+    if (condition()) return
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+  throw new Error("Timed out waiting for the card")
+}
+
+function mountCard() {
+  const host = document.createElement("div")
+  document.body.appendChild(host)
+  const handle = mount(host, { domain: "localhost", query: (builder) => builder.done() })
+  const state = () => host.querySelector(".zkp-card")?.getAttribute("data-state")
+  return { host, handle, state }
+}
+
+describe("Card", () => {
+  test("shows the connection lost state until the bridge comes back", async () => {
+    stubSdk()
+    const { host, handle, state } = mountCard()
+    await waitFor(() => state() === "connecting")
+
+    requests[0].fire("onBridgeConnect")
+    await waitFor(() => state() === "waiting")
+
+    requests[0].fire("onBridgeConnectionLost")
+    await waitFor(() => state() === "disconnected")
+    expect(host.querySelector(".zkp-overlay-caption")?.textContent).toBe("Connection lost")
+    expect(host.querySelector(".zkp-restart")).not.toBeNull()
+
+    requests[0].fire("onBridgeConnect")
+    await waitFor(() => state() === "waiting")
+    handle.unmount()
+  })
+
+  test("restart cancels the previous request", async () => {
+    stubSdk()
+    const { handle, state } = mountCard()
+    await waitFor(() => state() === "connecting")
+
+    handle.retry()
+    await waitFor(() => requests.length === 2)
+    expect(cancelled).toEqual(["request-1"])
+    handle.unmount()
+  })
+
+  test("unmount cancels the request, even one still being set up", async () => {
+    stubSdk()
+    const first = mountCard()
+    await waitFor(() => first.state() === "connecting")
+    first.handle.unmount()
+    expect(cancelled).toEqual(["request-1"])
+
+    holdRequests = true
+    const second = mountCard()
+    await waitFor(() => requests.length === 2)
+    second.handle.unmount()
+    requests[1].release()
+    await waitFor(() => cancelled.length === 2)
+    expect(cancelled).toEqual(["request-1", "request-2"])
+  })
+})

--- a/packages/zkpassport-ui/tests/card.test.ts
+++ b/packages/zkpassport-ui/tests/card.test.ts
@@ -1,8 +1,7 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import { afterAll, afterEach, beforeAll, describe, expect, spyOn, test } from "bun:test"
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, spyOn, test } from "bun:test"
 import { GlobalRegistrator } from "@happy-dom/global-registrator"
 import { ZKPassport } from "@zkpassport/sdk"
-import type { QueryBuilderResult } from "@zkpassport/sdk"
+import type { QueryBuilder, QueryBuilderResult } from "@zkpassport/sdk"
 import { mount } from "../src/vanilla"
 
 beforeAll(() => {
@@ -20,6 +19,7 @@ type FakeRequest = {
   fire: (event: string, ...args: unknown[]) => void
   // Resolve the pending sdk.request() call
   release: () => void
+  ready: Promise<void>
 }
 
 function fakeRequest(id: string): FakeRequest {
@@ -46,32 +46,37 @@ function fakeRequest(id: string): FakeRequest {
   const fire = (name: string, ...args: unknown[]) => {
     for (const callback of listeners[name] ?? []) callback(...args)
   }
-  return { request, fire, release: () => {} }
+  let release!: () => void
+  const ready = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  return { request, fire, release, ready }
 }
 
 const requests: FakeRequest[] = []
-const cancelled: string[] = []
+const sdkCalls: string[] = []
 let holdRequests = false
 let spies: Array<{ mockRestore: () => void }> = []
 
-function stubSdk() {
+beforeEach(() => {
   requests.length = 0
-  cancelled.length = 0
+  sdkCalls.length = 0
   holdRequests = false
   spies = [
-    spyOn(ZKPassport.prototype, "request").mockImplementation((() => {
+    spyOn(ZKPassport.prototype, "request").mockImplementation(() => {
       const fake = fakeRequest(`request-${requests.length + 1}`)
       requests.push(fake)
-      return new Promise((resolve) => {
-        fake.release = () => resolve({ done: () => fake.request })
-        if (!holdRequests) fake.release()
-      })
-    }) as any),
+      if (!holdRequests) fake.release()
+      return fake.ready.then(() => ({ done: () => fake.request }) as unknown as QueryBuilder)
+    }),
     spyOn(ZKPassport.prototype, "cancelRequest").mockImplementation((requestId: string) => {
-      cancelled.push(requestId)
+      sdkCalls.push(`cancelRequest:${requestId}`)
+    }),
+    spyOn(ZKPassport.prototype, "clearAllRequests").mockImplementation(() => {
+      sdkCalls.push("clearAllRequests")
     }),
   ]
-}
+})
 
 afterEach(() => {
   for (const spy of spies) spy.mockRestore()
@@ -87,6 +92,8 @@ async function waitFor(condition: () => boolean) {
   throw new Error("Timed out waiting for the card")
 }
 
+const settle = () => new Promise((resolve) => setTimeout(resolve, 50))
+
 function mountCard() {
   const host = document.createElement("div")
   document.body.appendChild(host)
@@ -97,7 +104,6 @@ function mountCard() {
 
 describe("Card", () => {
   test("shows the connection lost state until the bridge comes back", async () => {
-    stubSdk()
     const { host, handle, state } = mountCard()
     await waitFor(() => state() === "connecting")
 
@@ -107,37 +113,52 @@ describe("Card", () => {
     requests[0].fire("onBridgeConnectionLost")
     await waitFor(() => state() === "disconnected")
     expect(host.querySelector(".zkp-overlay-caption")?.textContent).toBe("Connection lost")
-    expect(host.querySelector(".zkp-restart")).not.toBeNull()
+    expect(host.querySelector(".zkp-retry")).not.toBeNull()
 
+    // Every failed retry round reports the loss again
+    requests[0].fire("onBridgeConnectionLost")
+    await settle()
     requests[0].fire("onBridgeConnect")
     await waitFor(() => state() === "waiting")
     handle.unmount()
   })
 
+  test("keeps the final screen when the connection is lost after a result", async () => {
+    const { handle, state } = mountCard()
+    await waitFor(() => state() === "connecting")
+
+    requests[0].fire("onBridgeConnect")
+    requests[0].fire("onSuccess", { proofs: [], result: {} })
+    await waitFor(() => state() === "success")
+
+    requests[0].fire("onBridgeConnectionLost")
+    await settle()
+    expect(state()).toBe("success")
+    handle.unmount()
+  })
+
   test("restart cancels the previous request", async () => {
-    stubSdk()
     const { handle, state } = mountCard()
     await waitFor(() => state() === "connecting")
 
     handle.retry()
     await waitFor(() => requests.length === 2)
-    expect(cancelled).toEqual(["request-1"])
+    expect(sdkCalls).toEqual(["clearAllRequests"])
     handle.unmount()
   })
 
   test("unmount cancels the request, even one still being set up", async () => {
-    stubSdk()
     const first = mountCard()
     await waitFor(() => first.state() === "connecting")
     first.handle.unmount()
-    expect(cancelled).toEqual(["request-1"])
+    expect(sdkCalls).toEqual(["clearAllRequests"])
 
     holdRequests = true
     const second = mountCard()
     await waitFor(() => requests.length === 2)
     second.handle.unmount()
     requests[1].release()
-    await waitFor(() => cancelled.length === 2)
-    expect(cancelled).toEqual(["request-1", "request-2"])
+    await waitFor(() => sdkCalls.length === 3)
+    expect(sdkCalls).toEqual(["clearAllRequests", "clearAllRequests", "cancelRequest:request-2"])
   })
 })


### PR DESCRIPTION
The card kept showing a QR code after the bridge had given up reconnecting. It now shows a "Connection lost" state with the restart button, and returns to where it was if the bridge comes back on a wake-up.

Restart and unmount only set a local flag, so the old bridge kept pinging and stayed registered on the server. Both now cancel the previous request.

happy-dom is added to render the card in tests.

### Rollout order
1. #287 merged, SDK published
2. Merge, publish `@zkpassport/ui`

### Related PRs
- Builds on #287
- Bridge side: obsidionlabs/obsidion-bridge#19
