### PR TITLE
fix(ui): Open the app link in a new tab so the requesting page survives

### DIFF
--- a/packages/zkpassport-ui/src/card.tsx
+++ b/packages/zkpassport-ui/src/card.tsx
@@ -139,7 +139,12 @@ export function Card({ options, controlRef }: CardProps) {
           {showOpenAppHero ? (
             <div className="zkp-open-app-hero">
               {state === "waiting" && url ? (
-                <a className="zkp-open-app zkp-open-app-block" href={url}>
+                <a
+                  className="zkp-open-app zkp-open-app-block"
+                  href={url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
                   Open ZKPassport App
                 </a>
               ) : (
@@ -161,7 +166,12 @@ export function Card({ options, controlRef }: CardProps) {
           )}
 
           {state === "waiting" && url && mobile && qrRevealed ? (
-            <a className="zkp-open-app zkp-open-app-block" href={url}>
+            <a
+              className="zkp-open-app zkp-open-app-block"
+              href={url}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               Open in ZKPassport App
             </a>
           ) : null}


### PR DESCRIPTION
For when the ZKPassport app is not installed. The app link then lands on the zkpassport.id interstitial and replaces the requesting page, so the result the app sends after install (Play install referrer) has nowhere to arrive. A new tab keeps that page alive.

Not needed with the flow where app is already installed 

### Key changes
- The two app links open in a new tab

### Related PRs
- Needs #288: the surviving page must reconnect to the bridge after the install to receive the result; #288 also brings the DOM test setup for a card test
- zkpassport/zkpassport-landing-webapp#34: the association fix that covers the installed case

### Rollout order
Test with store builds after #286–#288 ship.
