### PR TITLE
fix(ui): Drop the minimum card height in the phone layout

### DIFF
--- a/packages/zkpassport-ui/src/styles.css
+++ b/packages/zkpassport-ui/src/styles.css
@@ -469,6 +469,10 @@
     box-sizing: border-box !important;
   }
   /* Mobile-first waiting screen: open-app primary, QR behind a toggle */
+  /* The minimum card height fits the QR layout; the phone layout is much shorter */
+  .zkp-card:has(.zkp-open-app-hero) {
+    min-height: 0;
+  }
   .zkp-open-app-hero {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
On phones the card leads with the app button and keeps the QR behind a link (#241), but it kept the minimum height that was sized for the QR layout, so most of the card was an empty dark block. The minimum height now applies only when the QR layout is shown.

### Rollout order
Ships with the next `@zkpassport/ui` release.
