### PR TITLE
feat(ui,workspace): Add a script-tag build of the verify button

### DIFF
--- a/packages/verify-popup/README.md
+++ b/packages/verify-popup/README.md
@@ -13,6 +13,12 @@ bun run dev   # http://localhost:5173
 
 Point the button at it with `popupUrl="http://localhost:5173"`.
 
+## Script tag
+
+The build also serves `@zkpassport/ui`'s script-tag bundle at `/v1/zkpassport.js`, so
+the button script and the popup it opens always ship together. Anything served
+under `/v1/` must stay compatible with pages that embedded it earlier.
+
 ## Deployment
 
 Build with `bun run build` (static output in `dist/`). The host MUST send this

--- a/packages/verify-popup/package.json
+++ b/packages/verify-popup/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173",
-    "build": "vite build",
+    "build": "vite build && mkdir -p dist/v1 && cp ../zkpassport-ui/dist/cdn/* dist/v1/",
     "preview": "vite preview --port 5173",
     "clean": "rimraf dist tsconfig.tsbuildinfo",
     "check": "tsc --noEmit"

--- a/packages/zkpassport-ui/README.md
+++ b/packages/zkpassport-ui/README.md
@@ -92,6 +92,26 @@ For your own button, pass a function as `children`:
 
 Outside React, `createVerification(getOptions, onStateChange)` drives your own element: call `verify`, and `onStateChange` receives `{ status, error }`. `status` is `"idle" | "in-progress" | "success" | "error"`; `error` holds a message only when the user needs one, such as a blocked popup.
 
+## Script tag
+
+For sites without a bundler, one script serves the verify button from the popup's host. Every `[data-zkpassport]` element becomes a button; the query comes from a dashboard policy, so the HTML only names the policy.
+
+```html
+<div data-zkpassport data-policy-id="age-check" data-label="Verify your age"></div>
+
+<script src="https://verify.zkpassport.id/v1/zkpassport.js"></script>
+<script>
+  document.addEventListener("zkpassport:success", (event) => {
+    // event.detail is { proofs, result } — verify them on your backend
+    // event.preventDefault() shows the error state instead of success
+  })
+</script>
+```
+
+Optional attributes: `data-label`, `data-theme`, `data-size`, `data-dev-mode`, `data-popup-url`. The other outcomes fire `zkpassport:rejected`, `zkpassport:error` (`detail` is the message) and `zkpassport:closed`. `ZKPassport.scan(container)` mounts buttons added to the page later.
+
+For your own button, use `ZKPassport.createVerification(getOptions, onStateChange)` as described above, or `ZKPassport.mountVerifyButton(element, options)` for the branded button with JS callbacks.
+
 ## Callbacks
 
 All optional. The SDK lifecycle callbacks pass through verbatim — their signatures are derived from `@zkpassport/sdk`'s `QueryBuilderResult`, so any SDK change flows through here automatically.

--- a/packages/zkpassport-ui/README.md
+++ b/packages/zkpassport-ui/README.md
@@ -94,10 +94,12 @@ Outside React, `createVerification(getOptions, onStateChange)` drives your own e
 
 ## Script tag
 
-For sites without a bundler, one script serves the verify button from the popup's host. Every `[data-zkpassport]` element becomes a button; the query comes from a dashboard policy, so the HTML only names the policy.
+For sites without a bundler, one script serves the verify button from the popup's host. Every element with the class `zkpassport-button` becomes a button. The query comes from a dashboard policy, so the HTML only names the policy: a link carries it in its URL and its text becomes the label, any other element names it in `data-policy-id`.
 
 ```html
-<div data-zkpassport data-policy-id="age-check" data-label="Verify your age"></div>
+<a class="zkpassport-button" href="https://verify.zkpassport.id/?policy=age-check">Verify your age</a>
+<!-- or -->
+<div class="zkpassport-button" data-policy-id="age-check" data-label="Verify your age"></div>
 
 <script src="https://verify.zkpassport.id/v1/zkpassport.js"></script>
 <script>
@@ -108,7 +110,7 @@ For sites without a bundler, one script serves the verify button from the popup'
 </script>
 ```
 
-Optional attributes: `data-label`, `data-theme`, `data-size`, `data-dev-mode`, `data-popup-url`. The other outcomes fire `zkpassport:rejected`, `zkpassport:error` (`detail` is the message) and `zkpassport:closed`. `ZKPassport.scan(container)` mounts buttons added to the page later.
+The link is replaced by the button and keeps its class names, so listen for events on `document` or another ancestor. Optional attributes on either form: `data-label`, `data-theme`, `data-size`, `data-dev-mode`, `data-popup-url`. The other outcomes fire `zkpassport:rejected`, `zkpassport:error` (`detail` is the message) and `zkpassport:closed`. `ZKPassport.scan(container)` mounts buttons added to the page later.
 
 For your own button, use `ZKPassport.createVerification(getOptions, onStateChange)` as described above, or `ZKPassport.mountVerifyButton(element, options)` for the branded button with JS callbacks.
 

--- a/packages/zkpassport-ui/src/cdn/index.ts
+++ b/packages/zkpassport-ui/src/cdn/index.ts
@@ -1,0 +1,29 @@
+import { mountVerifyButton } from "../button/index"
+import { logger } from "../logger"
+import { createVerification } from "../verification"
+import { readButtonOptions } from "./options"
+
+const MOUNTED_ATTRIBUTE = "data-zkpassport-mounted"
+
+export function scan(root: ParentNode = document): void {
+  for (const element of root.querySelectorAll<HTMLElement>("[data-zkpassport]")) {
+    if (element.hasAttribute(MOUNTED_ATTRIBUTE)) continue
+    const options = readButtonOptions(element)
+    if (!options) {
+      logger.error("data-policy-id is required", element)
+      continue
+    }
+    element.setAttribute(MOUNTED_ATTRIBUTE, "")
+    mountVerifyButton(element, options)
+  }
+}
+
+if (typeof document !== "undefined") {
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", () => scan())
+  } else {
+    scan()
+  }
+}
+
+export { mountVerifyButton, createVerification }

--- a/packages/zkpassport-ui/src/cdn/index.ts
+++ b/packages/zkpassport-ui/src/cdn/index.ts
@@ -6,16 +6,26 @@ import { readButtonOptions } from "./options"
 const MOUNTED_ATTRIBUTE = "data-zkpassport-mounted"
 
 export function scan(root: ParentNode = document): void {
-  for (const element of root.querySelectorAll<HTMLElement>("[data-zkpassport]")) {
-    if (element.hasAttribute(MOUNTED_ATTRIBUTE)) continue
-    const options = readButtonOptions(element)
-    if (!options) {
-      logger.error("data-policy-id is required", element)
-      continue
-    }
-    element.setAttribute(MOUNTED_ATTRIBUTE, "")
-    mountVerifyButton(element, options)
+  for (const element of root.querySelectorAll<HTMLElement>(".zkpassport-button")) {
+    if (!element.hasAttribute(MOUNTED_ATTRIBUTE)) mountFromMarkup(element)
   }
+}
+
+// A link is replaced by the button; any other element gets the button inside
+function mountFromMarkup(element: HTMLElement): void {
+  const isLink = element.tagName === "A"
+  const container = isLink ? document.createElement("span") : element
+  const options = readButtonOptions(element, container)
+  if (!options) {
+    logger.error("policy missing: set data-policy-id or ?policy= in the link", element)
+    return
+  }
+  if (isLink) {
+    container.className = element.className
+    element.replaceWith(container)
+  }
+  container.setAttribute(MOUNTED_ATTRIBUTE, "")
+  mountVerifyButton(container, options)
 }
 
 if (typeof document !== "undefined") {

--- a/packages/zkpassport-ui/src/cdn/options.ts
+++ b/packages/zkpassport-ui/src/cdn/options.ts
@@ -1,0 +1,34 @@
+import {
+  BUTTON_FONT_SIZES,
+  type VerifyButtonSize,
+  type VerifyWithZKPassportButtonOptions,
+} from "../verify-button"
+
+type ButtonTheme = NonNullable<VerifyWithZKPassportButtonOptions["theme"]>
+
+export function readButtonOptions(element: HTMLElement): VerifyWithZKPassportButtonOptions | null {
+  const attribute = (name: string) => element.dataset[name] || undefined
+  const policyId = attribute("policyId")
+  if (!policyId) return null
+
+  const size = attribute("size")
+  const emit = (name: string, detail?: unknown, cancelable = false) =>
+    element.dispatchEvent(
+      new CustomEvent(`zkpassport:${name}`, { detail, bubbles: true, cancelable }),
+    )
+
+  return {
+    policyId,
+    label: attribute("label"),
+    theme: attribute("theme") as ButtonTheme | undefined,
+    size: size && size in BUTTON_FONT_SIZES ? (size as VerifyButtonSize) : undefined,
+    devMode: element.hasAttribute("data-dev-mode"),
+    popupUrl: attribute("popupUrl"),
+    query: (builder) => builder.done(),
+    // preventDefault() on the success event shows the error state instead
+    onSuccess: (response) => emit("success", response, true),
+    onReject: () => emit("rejected"),
+    onError: (message) => emit("error", message),
+    onClose: () => emit("closed"),
+  }
+}

--- a/packages/zkpassport-ui/src/cdn/options.ts
+++ b/packages/zkpassport-ui/src/cdn/options.ts
@@ -4,31 +4,32 @@ import {
   type VerifyWithZKPassportButtonOptions,
 } from "../verify-button"
 
-type ButtonTheme = NonNullable<VerifyWithZKPassportButtonOptions["theme"]>
-
-export function readButtonOptions(element: HTMLElement): VerifyWithZKPassportButtonOptions | null {
-  const attribute = (name: string) => element.dataset[name] || undefined
-  const policyId = attribute("policyId")
+export function readButtonOptions(
+  element: HTMLElement,
+  eventTarget: EventTarget = element,
+): VerifyWithZKPassportButtonOptions | null {
+  const dataAttribute = (name: string) => element.dataset[name] || undefined
+  const link = element.tagName === "A" ? (element as HTMLAnchorElement) : undefined
+  const linkUrl = link?.href ? new URL(link.href) : undefined
+  const policyId = dataAttribute("policyId") ?? linkUrl?.searchParams.get("policy")
   if (!policyId) return null
 
-  const size = attribute("size")
-  const emit = (name: string, detail?: unknown, cancelable = false) =>
-    element.dispatchEvent(
-      new CustomEvent(`zkpassport:${name}`, { detail, bubbles: true, cancelable }),
-    )
+  const size = dataAttribute("size")
+  const emit = (name: string, init: CustomEventInit = {}) =>
+    eventTarget.dispatchEvent(new CustomEvent(`zkpassport:${name}`, { bubbles: true, ...init }))
 
   return {
     policyId,
-    label: attribute("label"),
-    theme: attribute("theme") as ButtonTheme | undefined,
+    label: dataAttribute("label") ?? (link?.textContent?.trim() || undefined),
+    theme: dataAttribute("theme") as VerifyWithZKPassportButtonOptions["theme"],
     size: size && size in BUTTON_FONT_SIZES ? (size as VerifyButtonSize) : undefined,
     devMode: element.hasAttribute("data-dev-mode"),
-    popupUrl: attribute("popupUrl"),
+    popupUrl: dataAttribute("popupUrl") ?? linkUrl?.href,
     query: (builder) => builder.done(),
     // preventDefault() on the success event shows the error state instead
-    onSuccess: (response) => emit("success", response, true),
+    onSuccess: (response) => emit("success", { detail: response, cancelable: true }),
     onReject: () => emit("rejected"),
-    onError: (message) => emit("error", message),
+    onError: (message) => emit("error", { detail: message }),
     onClose: () => emit("closed"),
   }
 }

--- a/packages/zkpassport-ui/tests/cdn.test.ts
+++ b/packages/zkpassport-ui/tests/cdn.test.ts
@@ -2,10 +2,19 @@ import { describe, expect, test } from "bun:test"
 import { readButtonOptions } from "../src/cdn/options"
 
 class FakeElement extends EventTarget {
-  dataset: Record<string, string>
-  constructor(dataset: Record<string, string>) {
+  tagName = "DIV"
+  href?: string
+  textContent?: string
+  constructor(
+    public dataset: Record<string, string>,
+    link?: { href: string; text: string },
+  ) {
     super()
-    this.dataset = dataset
+    if (link) {
+      this.tagName = "A"
+      this.href = link.href
+      this.textContent = link.text
+    }
   }
   hasAttribute(name: string) {
     return name === "data-dev-mode" && "devMode" in this.dataset
@@ -15,8 +24,13 @@ class FakeElement extends EventTarget {
 const asElement = (fake: FakeElement) => fake as unknown as HTMLElement
 
 describe("readButtonOptions", () => {
-  test("requires data-policy-id", () => {
+  test("requires a policy", () => {
     expect(readButtonOptions(asElement(new FakeElement({ label: "Verify" })))).toBeNull()
+    const linkWithoutPolicy = new FakeElement(
+      {},
+      { href: "https://verify.zkpassport.id/", text: "Verify" },
+    )
+    expect(readButtonOptions(asElement(linkWithoutPolicy))).toBeNull()
   })
 
   test("maps data attributes to button options", () => {
@@ -41,13 +55,29 @@ describe("readButtonOptions", () => {
     })
   })
 
-  test("reports the outcome as events on the element", () => {
+  test("reads a link's policy from its URL and its text as the label", () => {
+    const link = new FakeElement(
+      {},
+      { href: "https://verify.zkpassport.id/?policy=pol_123", text: " Verify your age " },
+    )
+
+    const options = readButtonOptions(asElement(link))!
+
+    expect(options).toMatchObject({
+      policyId: "pol_123",
+      label: "Verify your age",
+      popupUrl: "https://verify.zkpassport.id/?policy=pol_123",
+    })
+  })
+
+  test("reports the outcome as events on the given target", () => {
     const element = new FakeElement({ policyId: "pol_123" })
+    const target = new EventTarget()
     const received: CustomEvent[] = []
     for (const name of ["success", "rejected", "error", "closed"]) {
-      element.addEventListener(`zkpassport:${name}`, (event) => received.push(event as CustomEvent))
+      target.addEventListener(`zkpassport:${name}`, (event) => received.push(event as CustomEvent))
     }
-    const options = readButtonOptions(asElement(element))!
+    const options = readButtonOptions(asElement(element), target)!
 
     options.onSuccess?.({ proofs: [], result: {} } as never)
     options.onReject?.()

--- a/packages/zkpassport-ui/tests/cdn.test.ts
+++ b/packages/zkpassport-ui/tests/cdn.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test"
+import { readButtonOptions } from "../src/cdn/options"
+
+class FakeElement extends EventTarget {
+  dataset: Record<string, string>
+  constructor(dataset: Record<string, string>) {
+    super()
+    this.dataset = dataset
+  }
+  hasAttribute(name: string) {
+    return name === "data-dev-mode" && "devMode" in this.dataset
+  }
+}
+
+const asElement = (fake: FakeElement) => fake as unknown as HTMLElement
+
+describe("readButtonOptions", () => {
+  test("requires data-policy-id", () => {
+    expect(readButtonOptions(asElement(new FakeElement({ label: "Verify" })))).toBeNull()
+  })
+
+  test("maps data attributes to button options", () => {
+    const element = new FakeElement({
+      policyId: "pol_123",
+      label: "Get verified",
+      theme: "dark",
+      size: "large",
+      devMode: "",
+      popupUrl: "http://localhost:5173",
+    })
+
+    const options = readButtonOptions(asElement(element))!
+
+    expect(options).toMatchObject({
+      policyId: "pol_123",
+      label: "Get verified",
+      theme: "dark",
+      size: "large",
+      devMode: true,
+      popupUrl: "http://localhost:5173",
+    })
+  })
+
+  test("reports the outcome as events on the element", () => {
+    const element = new FakeElement({ policyId: "pol_123" })
+    const received: CustomEvent[] = []
+    for (const name of ["success", "rejected", "error", "closed"]) {
+      element.addEventListener(`zkpassport:${name}`, (event) => received.push(event as CustomEvent))
+    }
+    const options = readButtonOptions(asElement(element))!
+
+    options.onSuccess?.({ proofs: [], result: {} } as never)
+    options.onReject?.()
+    options.onError?.("popup blocked")
+    options.onClose?.()
+
+    expect(received.map((event) => [event.type, event.detail])).toEqual([
+      ["zkpassport:success", { proofs: [], result: {} }],
+      ["zkpassport:rejected", null],
+      ["zkpassport:error", "popup blocked"],
+      ["zkpassport:closed", null],
+    ])
+  })
+
+  test("preventDefault on the success event vetoes the success state", () => {
+    const element = new FakeElement({ policyId: "pol_123" })
+    const options = readButtonOptions(asElement(element))!
+
+    expect(options.onSuccess?.({} as never)).toBe(true)
+    element.addEventListener("zkpassport:success", (event) => event.preventDefault())
+    expect(options.onSuccess?.({} as never)).toBe(false)
+  })
+})

--- a/packages/zkpassport-ui/tsup.config.ts
+++ b/packages/zkpassport-ui/tsup.config.ts
@@ -97,6 +97,23 @@ const hostedConfig: Options = {
   loader: { ".css": "text" },
 }
 
+// Script-tag build: one self-contained file exposing window.ZKPassport
+const cdnConfig: Options = {
+  entry: { zkpassport: "src/cdn/index.ts" },
+  format: "iife",
+  globalName: "ZKPassport",
+  outDir: "dist/cdn",
+  outExtension: () => ({ js: ".js" }),
+  clean: true,
+  splitting: false,
+  sourcemap: true,
+  treeshake: !isDev,
+  minify: !isDev,
+  platform: "browser",
+  esbuildPlugins: [stubUnreachableDeps],
+  loader: { ".css": "text" },
+}
+
 const cssConfig: Options = {
   entry: { styles: "src/styles.css" },
   outDir: "dist",
@@ -112,4 +129,4 @@ const cssConfig: Options = {
   },
 }
 
-export default defineConfig([...npmConfigs, hostedConfig, cssConfig])
+export default defineConfig([...npmConfigs, hostedConfig, cdnConfig, cssConfig])


### PR DESCRIPTION
Sites without a bundler get the verify button with one `<script>` tag. It only opens the hosted popup, so 16 KB is enough.

### Key changes
- `@zkpassport/ui` builds `dist/cdn/zkpassport.js`: any `.zkpassport-button` element becomes the button, and callbacks arrive as DOM events
- `verify-popup` serves it at `/v1/zkpassport.js`, so script and popup ship together

### Rollout order
1. Deploy `verify-popup`, whose build must build `@zkpassport/ui` first
2. Publish `@zkpassport/ui`

### Related PRs
- #241 verify button and hosted popup
- #196 dropped the earlier IIFE build, blocked then by in-browser proof verification
