### PR TITLE
feat(workspace): Support verification links in the hosted popup

### DIFF
--- a/packages/verify-popup/README.md
+++ b/packages/verify-popup/README.md
@@ -13,6 +13,13 @@ bun run dev   # http://localhost:5173
 
 Point the button at it with `popupUrl="http://localhost:5173"`.
 
+## Verification links
+
+`https://verify.zkpassport.id?vl=<link id>` runs the same card for a link created in the
+ZKPassport dashboard. The page loads the request from the dashboard API and posts the proofs
+back to it once the phone has answered. For a local API set
+`VITE_DASHBOARD_API_URL=http://localhost:3001`.
+
 ## Deployment
 
 Build with `bun run build` (static output in `dist/`). The host MUST send this
@@ -35,5 +42,6 @@ opener relationship and break result delivery to the relying party.
 
 The RP's identity is derived exclusively from the browser-attested
 `event.origin` of the `configure` postMessage — never from message payloads.
+In link mode it comes from the dashboard API, which owns the link.
 The mobile app's origin trust for `verify.zkpassport.id`
 (`ZKPASSPORT_TRUSTED_ORIGINS` in the app) depends on this invariant.

--- a/packages/verify-popup/src/App.tsx
+++ b/packages/verify-popup/src/App.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useMemo, useRef, useState } from "react"
 import {
-  hydrateQueryBuilder,
   isPopupMessage,
   type PopupConfigureMessage,
   type PopupEventMessage,
 } from "@zkpassport/sdk/popup"
-import { ZKPassportQRCode } from "@zkpassport/ui/hosted"
+
+import { Frame, Notice } from "./layout"
+import { LinkVerification } from "./link-verification"
+import { VerificationCard } from "./verification-card"
 
 type DistributiveOmit<T, K extends PropertyKey> = T extends unknown ? Omit<T, K> : never
 type OutgoingEvent = DistributiveOmit<PopupEventMessage, "zkpassport">
@@ -18,6 +20,7 @@ type Configuration = {
 }
 
 export function App() {
+  const linkId = new URLSearchParams(window.location.search).get("vl")
   const [config, setConfig] = useState<Configuration | null>(null)
   const [standalone, setStandalone] = useState(false)
   const closeTimer = useRef<number | null>(null)
@@ -58,13 +61,21 @@ export function App() {
     }
   }, [config])
 
+  if (linkId) {
+    return (
+      <Frame>
+        <LinkVerification linkId={linkId} />
+      </Frame>
+    )
+  }
+
   if (standalone) {
     return (
       <Frame>
-        <p style={styles.notice}>
+        <Notice>
           This page verifies your ID for websites that use ZKPassport. Open it from a website's
           "Verify with ZKPassport" button.
-        </p>
+        </Notice>
       </Frame>
     )
   }
@@ -72,13 +83,12 @@ export function App() {
   if (!config || !send) {
     return (
       <Frame>
-        <p style={styles.notice}>Connecting…</p>
+        <Notice>Connecting…</Notice>
       </Frame>
     )
   }
 
   const domain = new URL(config.rpOrigin).hostname
-  const request = config.request
 
   // Auto-close once the flow is complete (after the outcome screen has shown)
   const scheduleClose = (delayMs: number) => {
@@ -88,19 +98,8 @@ export function App() {
 
   return (
     <Frame>
-      <ZKPassportQRCode
-        domain={domain}
-        name={request.name ?? domain}
-        logo={request.logo}
-        purpose={request.purpose}
-        scope={request.scope}
-        mode={request.mode}
-        devMode={request.devMode}
-        validity={request.validity}
-        uniqueIdentifierType={request.uniqueIdentifierType}
-        oprfKeyId={request.oprfKeyId}
-        showIntroScreen
-        query={(builder) => hydrateQueryBuilder(builder, config.query)}
+      <VerificationCard
+        config={{ domain, request: config.request, query: config.query }}
         onRequestReceived={() => send({ type: "request-received" })}
         onGeneratingProof={() => send({ type: "generating" })}
         onProofGenerated={(proof) =>
@@ -119,37 +118,4 @@ export function App() {
       />
     </Frame>
   )
-}
-
-function Frame({ children }: { children: React.ReactNode }) {
-  return <div style={styles.frame}>{children}</div>
-}
-
-const styles: Record<string, React.CSSProperties> = {
-  frame: {
-    minHeight: "100vh",
-    display: "flex",
-    flexDirection: "column",
-    alignItems: "center",
-    justifyContent: "flex-start",
-    gap: 12,
-    padding: "16px 12px 24px",
-    boxSizing: "border-box",
-  },
-  notice: {
-    maxWidth: 320,
-    marginTop: 80,
-    textAlign: "center",
-    fontSize: 14,
-    lineHeight: 1.5,
-    color: "#6b7280",
-  },
-  hint: {
-    maxWidth: 340,
-    margin: 0,
-    textAlign: "center",
-    fontSize: 11.5,
-    lineHeight: 1.5,
-    color: "#9ca3af",
-  },
 }

--- a/packages/verify-popup/src/layout.tsx
+++ b/packages/verify-popup/src/layout.tsx
@@ -1,0 +1,30 @@
+import type { CSSProperties, ReactNode } from "react"
+
+export function Frame({ children }: { children: ReactNode }) {
+  return <div style={styles.frame}>{children}</div>
+}
+
+export function Notice({ children }: { children: ReactNode }) {
+  return <p style={styles.notice}>{children}</p>
+}
+
+const styles: Record<string, CSSProperties> = {
+  frame: {
+    minHeight: "100vh",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "flex-start",
+    gap: 12,
+    padding: "16px 12px 24px",
+    boxSizing: "border-box",
+  },
+  notice: {
+    maxWidth: 320,
+    marginTop: 80,
+    textAlign: "center",
+    fontSize: 14,
+    lineHeight: 1.5,
+    color: "#6b7280",
+  },
+}

--- a/packages/verify-popup/src/link-verification.tsx
+++ b/packages/verify-popup/src/link-verification.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useRef, useState } from "react"
+import type { ProofResult, QueryBuilderResult, QueryResult } from "@zkpassport/sdk"
+
+import { Notice } from "./layout"
+import { VerificationCard, type VerificationConfig } from "./verification-card"
+
+const DASHBOARD_API_URL = (
+  import.meta.env.VITE_DASHBOARD_API_URL || "https://dashboard-api.zkpassport.id"
+).replace(/\/$/, "")
+
+const UNAVAILABLE_MESSAGE = "The verification service is unavailable. Try again later."
+
+export function LinkVerification({ linkId }: { linkId: string }) {
+  const [config, setConfig] = useState<VerificationConfig | null>(null)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const activeSdkRequest = useRef<QueryBuilderResult | null>(null)
+
+  useEffect(() => {
+    fetchLink(linkId).then(setConfig, (error: Error) => setErrorMessage(error.message))
+  }, [linkId])
+
+  if (errorMessage) return <Notice>{errorMessage}</Notice>
+  if (!config) return <Notice>Loading…</Notice>
+
+  return (
+    <VerificationCard
+      config={config}
+      onRequestCreated={(sdkRequest) => {
+        activeSdkRequest.current = sdkRequest
+        registerAttempt(linkId, sdkRequest.requestId).catch((error: Error) =>
+          setErrorMessage(error.message),
+        )
+      }}
+      onSuccess={({ proofs, result }) => {
+        const sdkRequest = activeSdkRequest.current!
+        return submitResult(linkId, {
+          requestId: sdkRequest.requestId,
+          sdkVersion: new URL(sdkRequest.url).searchParams.get("v") ?? "",
+          proofs,
+          queryResult: result,
+        })
+      }}
+    />
+  )
+}
+
+async function fetchLink(linkId: string): Promise<VerificationConfig> {
+  const response = await dashboardFetch(linkPath(linkId))
+  const body = (await response.json()) as { link: VerificationConfig }
+  return body.link
+}
+
+async function registerAttempt(linkId: string, requestId: string): Promise<void> {
+  await dashboardFetch(`${linkPath(linkId)}/attempts`, postJson({ requestId }))
+}
+
+async function submitResult(
+  linkId: string,
+  result: {
+    requestId: string
+    sdkVersion: string
+    proofs: ProofResult[]
+    queryResult: QueryResult
+  },
+): Promise<void> {
+  await dashboardFetch(`${linkPath(linkId)}/results`, postJson(result))
+}
+
+function linkPath(linkId: string): string {
+  return `/public/verification-links/${encodeURIComponent(linkId)}`
+}
+
+function postJson(body: unknown): RequestInit {
+  return {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }
+}
+
+async function dashboardFetch(path: string, init?: RequestInit): Promise<Response> {
+  let response: Response
+  try {
+    response = await fetch(DASHBOARD_API_URL + path, init)
+  } catch {
+    throw new Error(UNAVAILABLE_MESSAGE)
+  }
+  if (!response.ok) {
+    const body = (await response.json().catch(() => null)) as { error?: string } | null
+    throw new Error(body?.error ?? UNAVAILABLE_MESSAGE)
+  }
+  return response
+}

--- a/packages/verify-popup/src/verification-card.tsx
+++ b/packages/verify-popup/src/verification-card.tsx
@@ -1,0 +1,49 @@
+import type { Query, QueryBuilderResult } from "@zkpassport/sdk"
+import { hydrateQueryBuilder, type PopupRequestConfig } from "@zkpassport/sdk/popup"
+import { ZKPassportQRCode, type ZKPassportQRCodeProps } from "@zkpassport/ui/hosted"
+
+export type VerificationConfig = {
+  domain: string
+  request: PopupRequestConfig
+  query: Query
+}
+
+type VerificationCardProps = Pick<
+  ZKPassportQRCodeProps,
+  | "onRequestReceived"
+  | "onGeneratingProof"
+  | "onProofGenerated"
+  | "onSuccess"
+  | "onReject"
+  | "onError"
+> & {
+  config: VerificationConfig
+  onRequestCreated?: (sdkRequest: QueryBuilderResult) => void
+}
+
+export function VerificationCard({ config, onRequestCreated, ...events }: VerificationCardProps) {
+  const { domain, request, query } = config
+
+  // Listed one by one so the opening website cannot pass extra request options
+  return (
+    <ZKPassportQRCode
+      domain={domain}
+      name={request.name ?? domain}
+      logo={request.logo}
+      purpose={request.purpose}
+      scope={request.scope}
+      mode={request.mode}
+      devMode={request.devMode}
+      validity={request.validity}
+      uniqueIdentifierType={request.uniqueIdentifierType}
+      oprfKeyId={request.oprfKeyId}
+      showIntroScreen
+      query={(builder) => {
+        const sdkRequest = hydrateQueryBuilder(builder, query)
+        onRequestCreated?.(sdkRequest)
+        return sdkRequest
+      }}
+      {...events}
+    />
+  )
+}

--- a/packages/verify-popup/src/vite-env.d.ts
+++ b/packages/verify-popup/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
Fix: https://linear.app/aztec-labs/issue/ZKP-426

Verification links let an organization ask someone to verify themselves without integrating anything. Opening one now runs the usual verification card on `verify.zkpassport.id`, so there is no separate page to host.

### Key changes
- `?vl=<link id>` loads the request from the dashboard and sends the proofs back.
- The existing popup flow is unchanged.

### Related PRs
- zkpassport/zkpassport-customer-dashboard#272

<img width="300" alt="Screenshot 2026-09-11 at 16 51 41" src="https://github.com/user-attachments/assets/0983dcad-1c68-4e59-905a-33ca12425605" />
<img width="300" alt="Screenshot 2026-09-11 at 16 52 01" src="https://github.com/user-attachments/assets/435edb70-c5d1-4b1e-aa96-86a79460cc36" />
<img width="300"alt="Screenshot 2026-09-11 at 16 52 46" src="https://github.com/user-attachments/assets/d752764b-59dd-4d75-944f-2cecbf489218" />
<img width="831" height="152" alt="Screenshot 2026-09-11 at 16 53 16" src="https://github.com/user-attachments/assets/31d9c0e4-1b67-4e0f-9458-b076df9c6ea7" />

